### PR TITLE
Redesign frontend to match Jobsy service marketplace identity

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About Us | Jobsy - Jamaica's Service Marketplace</title>
+  <title>About | Jobsy Jamaica</title>
   <meta name="description" content="Learn about Jobsy, a Jamaican service marketplace helping customers find local professionals across all 14 parishes.">
   <meta property="og:title" content="About Jobsy - Jamaica's Service Marketplace">
   <meta property="og:description" content="Learn about Jobsy, a Jamaican service marketplace for finding local professionals.">
@@ -15,7 +15,7 @@
 <body>
   <main>
     <div class="container">
-      <div class="tool-detail" style="max-width:800px">
+      <div class="service-detail" style="max-width:800px">
         <h1>About Jobsy</h1>
         <p class="text-muted">A Jamaican service marketplace</p>
 

--- a/category.html
+++ b/category.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Browse Services | Jobsy - Jamaica's Service Marketplace</title>
+  <title>Browse Services | Jobsy Jamaica</title>
   <meta name="description" content="Browse service providers by category and parish on Jobsy Jamaica.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Jobsy">
@@ -26,7 +26,7 @@
       <div class="category-bar" id="filter-bar"></div>
 
       <!-- Results Grid -->
-      <div class="tool-grid" id="results-grid">
+      <div class="service-grid" id="results-grid">
         <p class="text-center text-muted" style="grid-column:1/-1;padding:2rem">Loading services...</p>
       </div>
 
@@ -60,13 +60,13 @@
           filterLabel = cat.name;
           pageTitle.textContent = `${cat.icon} ${cat.name} in Jamaica`;
           pageDesc.textContent = cat.desc;
-          document.title = `${cat.name} Services | Jobsy Jamaica`;
-          document.querySelector('meta[name="description"]').content = `${cat.desc} Find trusted ${cat.name.toLowerCase()} providers on Jobsy.`;
+          document.title = `${cat.name} | Jobsy Jamaica`;
+          document.querySelector('meta[name="description"]').content = `${cat.desc} Browse ${cat.name.toLowerCase()} providers on Jobsy.`;
         }
       } else if (parish) {
         filterLabel = parish;
         pageTitle.textContent = `Services in ${parish}`;
-        pageDesc.textContent = `Find trusted service providers in ${parish}, Jamaica.`;
+        pageDesc.textContent = `Browse service providers in ${parish}, Jamaica.`;
         document.title = `Services in ${parish} | Jobsy Jamaica`;
         document.querySelector('meta[name="description"]').content = `Browse service providers in ${parish}, Jamaica on Jobsy.`;
       }

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact Us | Jobsy - Jamaica's Service Marketplace</title>
+  <title>Contact | Jobsy Jamaica</title>
   <meta name="description" content="Get in touch with the Jobsy team. Register as a service provider, ask questions, or explore business partnerships.">
   <meta property="og:title" content="Contact Jobsy">
   <meta property="og:description" content="Register your business or get in touch with Jobsy Jamaica.">
@@ -32,7 +32,7 @@
 <body>
   <main>
     <div class="container">
-      <div class="tool-detail" style="max-width:800px">
+      <div class="service-detail" style="max-width:800px">
         <h1>Contact Us</h1>
         <p class="text-muted">Jobsy Jamaica &mdash; Mandeville, Manchester</p>
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,11 @@
 /* ===== CSS Variables ===== */
 :root {
-  --primary: #009B3A;
-  --primary-dark: #007A2E;
-  --primary-light: #e6f7ed;
-  --accent: #FED100;
-  --accent-dark: #E0B800;
+  --primary: #1B5E20;
+  --primary-dark: #0D3B12;
+  --primary-light: #E8F5E9;
+  --primary-mid: #4CAF50;
+  --accent: #FFC107;
+  --accent-dark: #F9A825;
   --bg: #ffffff;
   --bg-alt: #f8fafc;
   --bg-dark: #0f172a;
@@ -19,7 +20,7 @@
   --radius-lg: 16px;
   --max-width: 1200px;
   --success: #10b981;
-  --gradient: linear-gradient(135deg, #009B3A 0%, #007A2E 50%, #005A22 100%);
+  --gradient: linear-gradient(135deg, #1B5E20 0%, #2E7D32 50%, #1B5E20 100%);
 }
 
 /* ===== Reset ===== */
@@ -58,7 +59,9 @@ p { margin-bottom: 1rem; }
   font-weight: 800; font-size: 1.25rem; color: var(--primary); text-decoration: none;
 }
 .nav-logo:hover { text-decoration: none; }
-.nav-links { display: none; list-style: none; gap: 0.25rem; }
+.nav-links {
+  display: none; list-style: none; gap: 0.25rem; align-items: center;
+}
 .nav-links a {
   display: block; padding: 0.5rem 0.75rem; border-radius: var(--radius);
   color: var(--text); font-size: 0.875rem; font-weight: 500; transition: background 0.15s;
@@ -67,17 +70,25 @@ p { margin-bottom: 1rem; }
 .nav-toggle {
   display: flex; align-items: center; justify-content: center;
   width: 40px; height: 40px; border: none; background: none; cursor: pointer; border-radius: var(--radius);
+  font-size: 1.5rem;
 }
 .nav-toggle:hover { background: var(--bg-alt); }
-.nav-toggle svg { width: 24px; height: 24px; color: var(--text); }
-.nav-mobile { display: none; padding: 0.5rem 1rem 1rem; border-bottom: 1px solid var(--border); background: var(--bg); }
-.nav-mobile.open { display: block; }
-.nav-mobile a { display: block; padding: 0.625rem 0.75rem; border-radius: var(--radius); color: var(--text); font-size: 0.9375rem; }
-.nav-mobile a:hover { background: var(--bg-alt); text-decoration: none; }
 @media (min-width: 768px) {
   .nav-links { display: flex; }
   .nav-toggle { display: none; }
-  .nav-mobile { display: none !important; }
+}
+
+/* Mobile menu - slides down below nav */
+.nav-links.open {
+  display: flex; flex-direction: column;
+  position: absolute; top: 64px; left: 0; right: 0;
+  background: var(--bg); border-bottom: 1px solid var(--border);
+  padding: 0.5rem 1rem 1rem; gap: 0.125rem; z-index: 99;
+}
+.nav-links.open a { padding: 0.75rem; font-size: 1rem; }
+@media (min-width: 768px) {
+  .nav-links.open { position: static; flex-direction: row; border: none; padding: 0; }
+  .nav-links.open a { padding: 0.5rem 0.75rem; font-size: 0.875rem; }
 }
 
 /* ===== Container ===== */
@@ -103,7 +114,10 @@ p { margin-bottom: 1rem; }
   display: flex; justify-content: center; gap: 2rem; margin-top: 2rem;
   font-size: 0.875rem; color: rgba(255,255,255,0.85);
 }
-.hero-stat-num { font-size: 1.5rem; font-weight: 800; display: block; }
+.hero-stat-num { font-size: 1.5rem; font-weight: 800; display: block; color: var(--accent); }
+.hero-actions {
+  display: flex; justify-content: center; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap;
+}
 
 /* ===== Category Pills ===== */
 .category-bar {
@@ -120,38 +134,36 @@ p { margin-bottom: 1rem; }
 .category-pill:hover { background: var(--primary-light); border-color: var(--primary); color: var(--primary); text-decoration: none; }
 .category-pill.active { background: var(--primary); border-color: var(--primary); color: white; }
 
-/* ===== Tool Card Grid ===== */
-.tool-grid { display: grid; grid-template-columns: 1fr; gap: 1.25rem; padding: 1rem 0 2rem; }
-@media (min-width: 640px) { .tool-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (min-width: 1024px) { .tool-grid { grid-template-columns: repeat(3, 1fr); } }
+/* ===== Service Card Grid ===== */
+.service-grid { display: grid; grid-template-columns: 1fr; gap: 1.25rem; padding: 1rem 0 2rem; }
+@media (min-width: 640px) { .service-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 1024px) { .service-grid { grid-template-columns: repeat(3, 1fr); } }
 
-.tool-card {
+.service-card {
   background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius-lg);
   padding: 1.5rem; transition: box-shadow 0.2s, transform 0.2s;
   text-decoration: none; color: var(--text); display: flex; flex-direction: column; gap: 0.75rem;
 }
-.tool-card:hover { box-shadow: var(--card-shadow-hover); transform: translateY(-3px); text-decoration: none; }
-.tool-card-header { display: flex; align-items: center; gap: 0.75rem; }
-.tool-card-icon {
+.service-card:hover { box-shadow: var(--card-shadow-hover); transform: translateY(-3px); text-decoration: none; }
+.service-card-header { display: flex; align-items: center; gap: 0.75rem; }
+.service-card-icon {
   width: 48px; height: 48px; border-radius: 12px;
   display: flex; align-items: center; justify-content: center;
   font-size: 1.5rem; background: var(--primary-light); flex-shrink: 0;
 }
-.tool-card-header h3 { color: var(--text); font-size: 1.0625rem; }
-.tool-card-header .tool-badge {
-  margin-left: auto; font-size: 0.6875rem; font-weight: 600;
-  padding: 0.2rem 0.5rem; border-radius: 50px; white-space: nowrap;
+.service-card-header h3 { color: var(--text); font-size: 1.0625rem; }
+.service-card-header .service-badge {
+  margin-left: auto; font-size: 0.8125rem; font-weight: 700;
+  padding: 0.25rem 0.625rem; border-radius: 50px; white-space: nowrap;
+  background: #FFF8E1; color: #F57F17;
 }
-.badge-free { background: #dcfce7; color: #16a34a; }
-.badge-freemium { background: #fef3c7; color: #b45309; }
-.badge-paid { background: #fee2e2; color: #dc2626; }
-.tool-card p { font-size: 0.875rem; color: var(--text-light); margin: 0; flex: 1; }
-.tool-card-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; }
-.tool-card-category {
-  font-size: 0.75rem; color: var(--text-light);
-  background: var(--bg-alt); padding: 0.2rem 0.625rem; border-radius: 50px;
+.service-card p { font-size: 0.875rem; color: var(--text-light); margin: 0; flex: 1; }
+.service-card-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; }
+.service-card-category {
+  font-size: 0.75rem; color: var(--primary);
+  background: var(--primary-light); padding: 0.25rem 0.75rem; border-radius: 50px; font-weight: 500;
 }
-.tool-card-rating { font-size: 0.8125rem; color: var(--accent); font-weight: 600; }
+.service-card-location { font-size: 0.8125rem; color: var(--text-light); display: flex; align-items: center; gap: 0.25rem; }
 
 /* ===== Section Heading ===== */
 .section-heading {
@@ -174,60 +186,34 @@ p { margin-bottom: 1rem; }
 .featured-banner h2 { color: white; }
 .featured-banner p { color: rgba(255,255,255,0.9); margin-bottom: 0.5rem; }
 
-/* ===== Tool Detail Page ===== */
-.tool-detail { padding: 2rem 0 3rem; }
-.tool-detail-header {
+/* ===== Service Detail Page ===== */
+.service-detail { padding: 2rem 0 3rem; }
+.service-detail-header {
   display: flex; flex-direction: column; gap: 1rem;
   padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); margin-bottom: 2rem;
 }
 @media (min-width: 768px) {
-  .tool-detail-header { flex-direction: row; align-items: flex-start; }
+  .service-detail-header { flex-direction: row; align-items: flex-start; }
 }
-.tool-detail-icon {
+.service-detail-icon {
   width: 72px; height: 72px; border-radius: 16px;
   display: flex; align-items: center; justify-content: center;
   font-size: 2rem; background: var(--primary-light); flex-shrink: 0;
 }
-.tool-detail-info { flex: 1; }
-.tool-detail-info h1 { margin-bottom: 0.25rem; }
-.tool-detail-meta {
+.service-detail-info { flex: 1; }
+.service-detail-info h1 { margin-bottom: 0.25rem; }
+.service-detail-meta {
   display: flex; flex-wrap: wrap; gap: 1rem; font-size: 0.875rem; color: var(--text-light); margin-top: 0.5rem;
 }
-.tool-detail-meta span { display: flex; align-items: center; gap: 0.25rem; }
-.tool-detail-actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1rem; }
+.service-detail-meta span { display: flex; align-items: center; gap: 0.25rem; }
+.service-detail-actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1rem; }
 
-.tool-detail-body { display: flex; flex-direction: column; gap: 2rem; }
+.service-detail-body { display: flex; flex-direction: column; gap: 2rem; }
 @media (min-width: 768px) {
-  .tool-detail-body { flex-direction: row; }
-  .tool-detail-main { flex: 2; }
-  .tool-detail-sidebar { flex: 1; }
+  .service-detail-body { flex-direction: row; }
+  .service-detail-main { flex: 2; }
+  .service-detail-sidebar { flex: 1; }
 }
-
-/* ===== Pros/Cons ===== */
-.pros-cons { display: grid; grid-template-columns: 1fr; gap: 1rem; margin: 1rem 0; }
-@media (min-width: 640px) { .pros-cons { grid-template-columns: 1fr 1fr; } }
-.pros-list, .cons-list {
-  padding: 1rem 1.25rem; border-radius: var(--radius); list-style: none;
-}
-.pros-list { background: #f0fdf4; border: 1px solid #bbf7d0; }
-.cons-list { background: #fef2f2; border: 1px solid #fecaca; }
-.pros-list h3 { color: #16a34a; margin-bottom: 0.5rem; }
-.cons-list h3 { color: #dc2626; margin-bottom: 0.5rem; }
-.pros-list li, .cons-list li {
-  padding: 0.25rem 0; font-size: 0.9375rem; padding-left: 1.25rem; position: relative;
-}
-.pros-list li::before { content: '+'; position: absolute; left: 0; color: #16a34a; font-weight: 700; }
-.cons-list li::before { content: '-'; position: absolute; left: 0; color: #dc2626; font-weight: 700; }
-
-/* ===== Pricing Table ===== */
-.pricing-table {
-  width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.9375rem;
-}
-.pricing-table th, .pricing-table td {
-  padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid var(--border);
-}
-.pricing-table th { background: var(--bg-alt); font-weight: 600; font-size: 0.8125rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-light); }
-.pricing-table tr:hover { background: var(--bg-alt); }
 
 /* ===== Sidebar Card ===== */
 .sidebar-card {
@@ -244,6 +230,15 @@ p { margin-bottom: 1rem; }
 .cta-box h3 { color: white; font-size: 1.125rem; margin-bottom: 0.5rem; }
 .cta-box p { color: rgba(255,255,255,0.9); font-size: 0.875rem; margin-bottom: 1rem; }
 
+/* ===== App Download Banner ===== */
+.app-banner {
+  background: var(--bg-dark); border-radius: var(--radius-lg);
+  padding: 2rem; color: white; margin: 2rem 0; text-align: center;
+}
+.app-banner h2 { color: white; margin-bottom: 0.5rem; }
+.app-banner p { color: rgba(255,255,255,0.7); margin-bottom: 1.25rem; }
+.app-banner-actions { display: flex; justify-content: center; gap: 0.75rem; flex-wrap: wrap; }
+
 /* ===== Buttons ===== */
 .btn {
   display: inline-flex; align-items: center; gap: 0.375rem;
@@ -255,13 +250,16 @@ p { margin-bottom: 1rem; }
 .btn:active { transform: scale(0.97); }
 .btn-primary { background: var(--primary); color: white; }
 .btn-primary:hover { background: var(--primary-dark); }
-.btn-accent { background: var(--accent); color: white; }
+.btn-accent { background: var(--accent); color: #1a1a1a; font-weight: 700; }
 .btn-accent:hover { background: var(--accent-dark); }
 .btn-outline { background: transparent; color: var(--primary); border: 2px solid var(--primary); }
 .btn-outline:hover { background: var(--primary-light); }
 .btn-white { background: white; color: var(--primary-dark); }
 .btn-white:hover { background: var(--bg-alt); }
+.btn-dark { background: var(--bg-dark); color: white; }
+.btn-dark:hover { background: #1e293b; }
 .btn-lg { padding: 0.875rem 2rem; font-size: 1.0625rem; }
+.btn-sm { padding: 0.5rem 1rem; font-size: 0.8125rem; }
 
 /* ===== Breadcrumbs ===== */
 .breadcrumbs { padding: 1rem 0 0; font-size: 0.875rem; color: var(--text-light); }
@@ -312,6 +310,25 @@ p { margin-bottom: 1rem; }
 .footer-social a { color: rgba(255,255,255,0.85); font-size: 0.875rem; font-weight: 500; }
 .footer-social a:hover { color: white; text-decoration: none; }
 
+/* ===== How It Works ===== */
+.how-it-works {
+  display: grid; grid-template-columns: 1fr; gap: 1.5rem;
+  padding: 1.5rem 0 2rem;
+}
+@media (min-width: 768px) { .how-it-works { grid-template-columns: repeat(3, 1fr); } }
+.how-step {
+  text-align: center; padding: 1.5rem;
+  background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius-lg);
+}
+.how-step-num {
+  width: 40px; height: 40px; border-radius: 50%;
+  background: var(--primary); color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 700; font-size: 1.125rem; margin-bottom: 0.75rem;
+}
+.how-step h3 { margin-bottom: 0.5rem; }
+.how-step p { color: var(--text-light); font-size: 0.875rem; margin: 0; }
+
 /* ===== Utility ===== */
 .mt-1 { margin-top: 0.5rem; }
 .mt-2 { margin-top: 1rem; }
@@ -329,9 +346,9 @@ p { margin-bottom: 1rem; }
 }
 .parish-tag {
   display: inline-block; padding: 0.5rem 1.25rem;
-  background: var(--primary-light); border: 1px solid var(--primary);
+  background: var(--primary-light); border: 1px solid var(--primary-mid);
   border-radius: 50px; font-size: 0.875rem; font-weight: 500;
-  color: var(--primary-dark); text-decoration: none; transition: all 0.15s;
+  color: var(--primary); text-decoration: none; transition: all 0.15s;
 }
 a.parish-tag:hover { background: var(--primary); color: white; text-decoration: none; }
 

--- a/disclosure.html
+++ b/disclosure.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Affiliate Disclosure | Jobsy - Jamaica's Service Marketplace</title>
+  <title>Affiliate Disclosure | Jobsy Jamaica</title>
   <meta name="description" content="Jobsy affiliate disclosure. Learn about our affiliate partnerships, how we earn revenue, and our commitment to transparency.">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <main>
     <div class="container">
-      <div class="tool-detail" style="max-width:800px">
+      <div class="service-detail" style="max-width:800px">
         <h1>Affiliate Disclosure</h1>
         <p class="text-muted">Last updated: March 9, 2026</p>
 

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Jobsy - Jamaica's Service Marketplace | Find Trusted Local Professionals</title>
+  <title>Jobsy - Find Service Providers in Jamaica</title>
   <meta name="description" content="Find local service providers across Jamaica. Plumbing, electrical, cleaning, beauty, events, tutoring, and more — browse by category or parish.">
   <meta name="keywords" content="Jamaica services, Jamaican service providers, hire professionals Jamaica, plumber Jamaica, electrician Jamaica, cleaning services Jamaica, Jobsy">
   <link rel="canonical" href="https://www.jobsyja.com/">
-  <meta property="og:title" content="Jobsy - Jamaica's Service Marketplace">
+  <meta property="og:title" content="Jobsy - Find Service Providers in Jamaica">
   <meta property="og:description" content="Find local service providers across Jamaica. Browse by category or parish.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.jobsyja.com/">
   <meta property="og:site_name" content="Jobsy">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Jobsy - Jamaica's Service Marketplace">
+  <meta name="twitter:title" content="Jobsy - Find Service Providers in Jamaica">
   <meta name="twitter:description" content="Find local service providers across Jamaica.">
   <link rel="stylesheet" href="css/style.css">
   <script type="application/ld+json">
@@ -65,9 +65,9 @@
         <input type="text" id="hero-search" placeholder="Search services... (e.g. plumber, cleaner, tutor)" aria-label="Search services">
       </div>
       <div class="hero-stats">
-        <div><span class="hero-stat-num" id="stat-listings">12+</span> Service Types</div>
+        <div><span class="hero-stat-num" id="stat-listings">12+</span> Services</div>
         <div><span class="hero-stat-num">12</span> Categories</div>
-        <div><span class="hero-stat-num">14</span> Parishes Covered</div>
+        <div><span class="hero-stat-num">14</span> Parishes</div>
       </div>
     </div>
   </section>
@@ -80,8 +80,30 @@
       <div class="ad-slot" data-ad-format="horizontal" data-ad-slot="home-top"></div>
 
       <!-- Service Grid -->
-      <div class="tool-grid" id="tool-grid">
+      <div class="service-grid" id="service-grid">
         <p class="text-center text-muted" style="grid-column:1/-1;padding:2rem">Loading services...</p>
+      </div>
+
+      <!-- How It Works -->
+      <div class="section-heading">
+        <h2>How It Works</h2>
+      </div>
+      <div class="how-it-works">
+        <div class="how-step">
+          <div class="how-step-num">1</div>
+          <h3>Search</h3>
+          <p>Type what you need or browse by category and parish.</p>
+        </div>
+        <div class="how-step">
+          <div class="how-step-num">2</div>
+          <h3>Compare</h3>
+          <p>View prices, descriptions, and locations side by side.</p>
+        </div>
+        <div class="how-step">
+          <div class="how-step-num">3</div>
+          <h3>Connect</h3>
+          <p>Contact the provider directly through the Jobsy app.</p>
+        </div>
       </div>
 
       <!-- Featured Banner -->
@@ -99,21 +121,23 @@
       <div class="section-heading">
         <h2>Browse by Category</h2>
       </div>
-      <div class="tool-grid" id="category-grid"></div>
+      <div class="service-grid" id="category-grid"></div>
 
-      <!-- Telegram Bot Promo -->
-      <div class="newsletter" style="background: linear-gradient(135deg, #0088cc 0%, #005fa3 100%); color: #fff;">
-        <h2 style="color: #fff;">Get Deals & Updates on Telegram</h2>
-        <p>Get notified about deals and new services from Jamaican businesses.</p>
-        <div class="newsletter-form">
-          <a href="https://t.me/JobsyDealBot" class="btn btn-primary" style="background: #fff; color: #0088cc; text-decoration: none; font-weight: bold; padding: 12px 32px; border-radius: 6px; display: inline-block;">Chat with @JobsyDealBot</a>
+      <!-- App Download Banner -->
+      <div class="app-banner">
+        <h2>Get the Jobsy App</h2>
+        <p>Swipe through services, chat with providers, and book jobs from your phone.</p>
+        <div class="app-banner-actions">
+          <a href="contact.html" class="btn btn-accent btn-lg">Download the App</a>
+          <a href="https://t.me/JobsyDealBot" class="btn btn-white btn-lg">Telegram Bot</a>
         </div>
-        <p class="text-sm mt-1" style="opacity: 0.85;">Free to use. No spam.</p>
       </div>
+
+      <div class="ad-slot" data-ad-format="horizontal" data-ad-slot="home-mid2"></div>
 
       <!-- Newsletter -->
       <div class="newsletter">
-        <h2>Stay Updated on Jamaican Services</h2>
+        <h2>Stay Updated</h2>
         <p>We send updates when new providers join or when there are deals worth knowing about.</p>
         <div class="newsletter-form">
           <input type="email" placeholder="Enter your email" aria-label="Email for newsletter">
@@ -173,14 +197,14 @@
           return slug === c.slug || (l.category || '').toLowerCase() === c.name.toLowerCase();
         }).length;
         return `
-          <a href="category.html?cat=${c.slug}" class="tool-card">
-            <div class="tool-card-header">
-              <div class="tool-card-icon">${c.icon}</div>
+          <a href="category.html?cat=${c.slug}" class="service-card">
+            <div class="service-card-header">
+              <div class="service-card-icon">${c.icon}</div>
               <h3>${c.name}</h3>
             </div>
             <p>${c.desc}</p>
-            <div class="tool-card-footer">
-              <span class="tool-card-category">${count} service${count !== 1 ? 's' : ''}</span>
+            <div class="service-card-footer">
+              <span class="service-card-category">${count} service${count !== 1 ? 's' : ''}</span>
             </div>
           </a>`;
       }).join('');

--- a/js/common.js
+++ b/js/common.js
@@ -29,9 +29,9 @@ const FALLBACK_LISTINGS = [
   { id: 'fb-4', title: 'Natural Hair Styling', description: 'Professional styling, braiding, locs, and makeup artistry. Mobile service available.', category: 'Beauty & Wellness', parish: 'St. Andrew', budget: 4000, currency: 'JMD' },
   { id: 'fb-5', title: 'Auto Repair & Detailing', description: 'Full-service automotive repair, engine diagnostics, AC service, and premium detailing.', category: 'Automotive', parish: 'St. Catherine', budget: 8000, currency: 'JMD' },
   { id: 'fb-6', title: 'Web Development & IT', description: 'Professional websites, office network setup, and IT consulting for small businesses.', category: 'Technology', parish: 'St. James', budget: 45000, currency: 'JMD' },
-  { id: 'fb-7', title: 'CXC Math Tutoring', description: 'Expert CXC and CAPE preparation. Proven track record of Grade 1 results.', category: 'Tutoring & Education', parish: 'Manchester', budget: 3000, currency: 'JMD' },
+  { id: 'fb-7', title: 'CXC Math Tutoring', description: 'CXC and CAPE preparation with consistent Grade 1 results.', category: 'Tutoring & Education', parish: 'Manchester', budget: 3000, currency: 'JMD' },
   { id: 'fb-8', title: 'Wedding Planning Package', description: 'Full wedding coordination from venue selection to day-of management.', category: 'Events & Entertainment', parish: 'Portland', budget: 80000, currency: 'JMD' },
-  { id: 'fb-9', title: 'Personal Training', description: 'Customized workout plans with nutrition guidance. Online and in-person sessions.', category: 'Health & Fitness', parish: 'Clarendon', budget: 20000, currency: 'JMD' },
+  { id: 'fb-9', title: 'Personal Training', description: 'Workout plans and nutrition guidance. Online and in-person sessions available.', category: 'Health & Fitness', parish: 'Clarendon', budget: 20000, currency: 'JMD' },
   { id: 'fb-10', title: 'Small Business Tax Filing', description: 'Annual GCT and income tax preparation. Statutory compliance included.', category: 'Professional Services', parish: 'Westmoreland', budget: 25000, currency: 'JMD' },
   { id: 'fb-11', title: 'Brand Identity Package', description: 'Logo design, business cards, social media templates. 3 concept rounds included.', category: 'Creative Services', parish: 'Trelawny', budget: 30000, currency: 'JMD' },
   { id: 'fb-12', title: 'Bathroom Renovation', description: 'Complete bathroom remodel including tiling, fixtures, and plumbing.', category: 'Construction', parish: 'St. Ann', budget: 120000, currency: 'JMD' }
@@ -118,13 +118,13 @@ function renderNav() {
   nav.className = 'nav';
   nav.innerHTML = `
     <div class="nav-inner">
-      <a href="index.html" class="nav-logo">${SITE_NAME}<span class="nav-logo-tag">Jamaica</span></a>
-      <div class="nav-links" id="mobile-menu">
+      <a href="index.html" class="nav-logo">${SITE_NAME}<span class="nav-logo-tag">JA</span></a>
+      <div class="nav-links" id="nav-menu">
         <a href="index.html">Home</a>
+        <a href="category.html">Services</a>
         <a href="about.html">About</a>
         <a href="contact.html">Contact</a>
-        <a href="disclosure.html">Disclosure</a>
-        <a href="https://t.me/JobsyDealBot" target="_blank" rel="noopener" class="btn btn-sm btn-primary">Telegram Bot</a>
+        <a href="https://t.me/JobsyDealBot" target="_blank" rel="noopener" class="btn btn-sm btn-accent">Telegram Bot</a>
       </div>
       <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false">&#9776;</button>
     </div>
@@ -132,10 +132,15 @@ function renderNav() {
   document.body.prepend(nav);
 
   const toggle = nav.querySelector('.nav-toggle');
-  const menu = nav.querySelector('#mobile-menu');
+  const menu = nav.querySelector('#nav-menu');
   toggle.addEventListener('click', () => {
     const open = menu.classList.toggle('open');
     toggle.setAttribute('aria-expanded', open);
+  });
+
+  // Close menu when clicking a link (mobile)
+  menu.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => menu.classList.remove('open'));
   });
 }
 
@@ -159,13 +164,13 @@ function renderFooter() {
           ${CATEGORIES.slice(0, 6).map(c => `<a href="category.html?cat=${c.slug}">${c.name}</a>`).join('')}
         </div>
         <div>
-          <h4>More</h4>
+          <h4>More Services</h4>
           ${CATEGORIES.slice(6).map(c => `<a href="category.html?cat=${c.slug}">${c.name}</a>`).join('')}
         </div>
         <div>
           <h4>Links</h4>
           <a href="index.html">Home</a>
-          <a href="about.html">About Us</a>
+          <a href="about.html">About</a>
           <a href="contact.html">Contact</a>
           <a href="privacy.html">Privacy Policy</a>
           <a href="disclosure.html">Affiliate Disclosure</a>
@@ -173,7 +178,7 @@ function renderFooter() {
       </div>
       <div class="footer-bottom">
         <span>&copy; ${new Date().getFullYear()} ${SITE_NAME} Jamaica. All rights reserved.</span>
-        <span>Find services across Jamaica.</span>
+        <span>Mandeville, Manchester, Jamaica</span>
       </div>
     </div>
   `;
@@ -207,18 +212,18 @@ function listingCardHTML(listing) {
     : 'Get Quote';
 
   return `
-    <a href="provider.html?id=${encodeURIComponent(listing.id)}" class="tool-card">
-      <div class="tool-card-header">
-        <div class="tool-card-icon">${icon}</div>
+    <a href="provider.html?id=${encodeURIComponent(listing.id)}" class="service-card">
+      <div class="service-card-header">
+        <div class="service-card-icon">${icon}</div>
         <div>
           <h3>${escapeHtml(listing.title)}</h3>
         </div>
-        <span class="tool-badge badge-freemium">${price}</span>
+        <span class="service-badge">${price}</span>
       </div>
       <p>${escapeHtml(listing.description || '')}</p>
-      <div class="tool-card-footer">
-        <span class="tool-card-category">${escapeHtml(catName)}</span>
-        ${parish ? `<span class="tool-card-rating">${escapeHtml(parish)}</span>` : ''}
+      <div class="service-card-footer">
+        <span class="service-card-category">${escapeHtml(catName)}</span>
+        ${parish ? `<span class="service-card-location">&#128205; ${escapeHtml(parish)}</span>` : ''}
       </div>
     </a>`;
 }
@@ -259,7 +264,7 @@ function initSearch() {
 }
 
 function renderListingGrid(listings) {
-  const grid = document.getElementById('tool-grid');
+  const grid = document.getElementById('service-grid');
   if (!grid) return;
   if (!listings || listings.length === 0) {
     grid.innerHTML = '<p class="text-center text-muted" style="grid-column:1/-1;padding:2rem">No services found matching your search.</p>';

--- a/privacy.html
+++ b/privacy.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Privacy Policy | Jobsy - Jamaica's Service Marketplace</title>
+  <title>Privacy Policy | Jobsy Jamaica</title>
   <meta name="description" content="Jobsy privacy policy. Learn how we handle your data and protect your privacy.">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <main>
     <div class="container">
-      <div class="tool-detail" style="max-width:800px">
+      <div class="service-detail" style="max-width:800px">
         <h1>Privacy Policy</h1>
         <p class="text-muted">Last updated: March 9, 2026</p>
 

--- a/provider.html
+++ b/provider.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Service Provider | Jobsy - Jamaica's Service Marketplace</title>
-  <meta name="description" content="View service provider details, listings, and reviews on Jobsy Jamaica.">
+  <title>Service Provider | Jobsy Jamaica</title>
+  <meta name="description" content="View service provider details and listings on Jobsy Jamaica.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Jobsy">
   <meta name="twitter:card" content="summary">
@@ -17,7 +17,7 @@
         <a href="index.html">Home</a> <span>&rsaquo;</span> <span id="breadcrumb-title">Service</span>
       </div>
 
-      <div class="tool-detail" id="provider-detail">
+      <div class="service-detail" id="provider-detail">
         <p class="text-center text-muted" style="padding:3rem">Loading service details...</p>
       </div>
     </div>
@@ -67,25 +67,25 @@
         : 'Get Quote';
 
       container.innerHTML = `
-        <div class="tool-detail-header">
-          <div class="tool-detail-icon">${icon}</div>
-          <div class="tool-detail-info">
+        <div class="service-detail-header">
+          <div class="service-detail-icon">${icon}</div>
+          <div class="service-detail-info">
             <h1>${escapeHtml(listing.title)}</h1>
-            <div class="tool-detail-meta">
+            <div class="service-detail-meta">
               <span>${escapeHtml(listing.category || 'Service')}</span>
               ${listing.parish ? `<span>&#128205; ${escapeHtml(listing.parish)}</span>` : ''}
               <span>&#128176; ${price}</span>
               ${listing.status ? `<span>Status: ${escapeHtml(listing.status)}</span>` : ''}
             </div>
-            <div class="tool-detail-actions">
+            <div class="service-detail-actions">
               <a href="contact.html" class="btn btn-primary">Contact Provider</a>
               ${listing.category ? `<a href="category.html?cat=${categorySlug(listing.category)}" class="btn btn-outline">More ${escapeHtml(listing.category)}</a>` : ''}
             </div>
           </div>
         </div>
 
-        <div class="tool-detail-body">
-          <div class="tool-detail-main">
+        <div class="service-detail-body">
+          <div class="service-detail-main">
             <div class="content-section">
               <h2>About This Service</h2>
               <p>${escapeHtml(listing.description || 'No description available.')}</p>
@@ -108,7 +108,7 @@
             <div class="content-section" id="similar-section"></div>
           </div>
 
-          <div class="tool-detail-sidebar">
+          <div class="service-detail-sidebar">
             <div class="sidebar-card">
               <h3>Service Details</h3>
               <p><strong>Category:</strong> ${escapeHtml(listing.category || 'Service')}</p>
@@ -118,7 +118,7 @@
 
             <div class="cta-box">
               <h3>Need This Service?</h3>
-              <p>Download the Jobsy app to connect directly with this provider.</p>
+              <p>Download the Jobsy app to message this provider directly.</p>
               <a href="contact.html" class="btn btn-white" style="width:100%;justify-content:center">Get Started</a>
             </div>
           </div>
@@ -136,7 +136,7 @@
         if (related.length) {
           similar.innerHTML = `
             <h2>Similar Services</h2>
-            <div class="tool-grid">${related.map(l => listingCardHTML(l)).join('')}</div>
+            <div class="service-grid">${related.map(l => listingCardHTML(l)).join('')}</div>
           `;
         }
       }


### PR DESCRIPTION
- Rename all tool-* CSS classes to service-* (service-card, service-grid, service-detail) to reflect the actual product
- Update color scheme to match mobile app: primary #1B5E20, accent #FFC107
- Fix mobile navigation toggle (CSS now targets .nav-links.open correctly)
- Add "How It Works" section and app download banner to homepage
- Add Services link to main navigation
- Clean up page titles to consistent "Page | Jobsy Jamaica" format
- Replace Telegram Bot nav link with accent-colored button
- Add close-on-click behavior for mobile menu links
- Update stat numbers to use gold accent color
- Add location pin icons to service card footers

https://claude.ai/code/session_0164NJLrfF52CBm6RhCMn8Ei