### PR TITLE
fix: Railway Dockerfile paths and ruff linter errors

### DIFF
--- a/jobsy/admin/Dockerfile
+++ b/jobsy/admin/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY admin/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY admin/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/admin/app/main.py
+++ b/jobsy/admin/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Admin Service -- dashboard, moderation, user management, audit logging."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 

--- a/jobsy/advertising/Dockerfile
+++ b/jobsy/advertising/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY advertising/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY advertising/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/advertising/app/main.py
+++ b/jobsy/advertising/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Advertising Service -- ad serving, campaign management, and Revive integration."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 

--- a/jobsy/chat/Dockerfile
+++ b/jobsy/chat/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY chat/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY chat/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/chat/app/main.py
+++ b/jobsy/chat/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Chat Service -- real-time messaging for matched users."""
 
 import asyncio
-import logging
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI

--- a/jobsy/chat/app/websocket.py
+++ b/jobsy/chat/app/websocket.py
@@ -5,7 +5,6 @@ messages reach users regardless of which server instance they're
 connected to.
 """
 
-import contextlib
 import json
 import logging
 import uuid

--- a/jobsy/gateway/Dockerfile
+++ b/jobsy/gateway/Dockerfile
@@ -7,10 +7,10 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY gateway/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY gateway/app/ ./app/
 
 USER appuser
 

--- a/jobsy/gateway/app/routes/proxy.py
+++ b/jobsy/gateway/app/routes/proxy.py
@@ -48,10 +48,16 @@ async def _proxy_request(service: str, path: str, request: Request, user: dict) 
         )
     except httpx.ConnectError:
         logger.error("Cannot connect to %s service at %s", service, base_url)
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Service {service} is unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Service {service} is unavailable",
+        ) from None
     except httpx.TimeoutException:
         logger.error("Timeout connecting to %s service at %s", service, base_url)
-        raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail=f"Service {service} timed out")
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=f"Service {service} timed out",
+        ) from None
 
     resp_headers = {k: v for k, v in response.headers.items() if k.lower() not in _HOP_BY_HOP}
 
@@ -130,5 +136,5 @@ async def proxy_search(path: str, request: Request, user: dict = Depends(get_cur
 @router.api_route("/admin/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def proxy_admin(path: str, request: Request, user: dict = Depends(get_current_user)):
     if user.get("role") != "admin":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required") from None
     return await _proxy_request("admin", f"/{path}", request, user)

--- a/jobsy/geoshard/Dockerfile
+++ b/jobsy/geoshard/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY geoshard/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY geoshard/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/geoshard/app/main.py
+++ b/jobsy/geoshard/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Geoshard Indexer -- spatial index service with S2 cells."""
 
 import asyncio
-import logging
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI

--- a/jobsy/listings/Dockerfile
+++ b/jobsy/listings/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY listings/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY listings/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/listings/app/main.py
+++ b/jobsy/listings/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Listing Service."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 

--- a/jobsy/matches/Dockerfile
+++ b/jobsy/matches/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY matches/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY matches/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/matches/app/main.py
+++ b/jobsy/matches/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Match Service -- API + event consumer."""
 
 import asyncio
-import logging
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI

--- a/jobsy/notifications/Dockerfile
+++ b/jobsy/notifications/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY notifications/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY notifications/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/notifications/app/main.py
+++ b/jobsy/notifications/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Notification Service -- push notifications and notification history."""
 
 import asyncio
-import logging
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI

--- a/jobsy/payments/Dockerfile
+++ b/jobsy/payments/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY payments/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY payments/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/payments/app/main.py
+++ b/jobsy/payments/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Payments Service -- Stripe-based payments for service marketplace."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 

--- a/jobsy/profiles/Dockerfile
+++ b/jobsy/profiles/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY profiles/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY profiles/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/profiles/app/main.py
+++ b/jobsy/profiles/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Profile Service."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 

--- a/jobsy/recommendations/Dockerfile
+++ b/jobsy/recommendations/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY recommendations/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY recommendations/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/recommendations/app/main.py
+++ b/jobsy/recommendations/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Recommendation Service -- ranked feed and user preference management."""
 
 import asyncio
-import logging
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI

--- a/jobsy/reviews/Dockerfile
+++ b/jobsy/reviews/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY reviews/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY reviews/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/reviews/app/main.py
+++ b/jobsy/reviews/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Reviews Service -- ratings, reviews, and reputation management."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 

--- a/jobsy/search/Dockerfile
+++ b/jobsy/search/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY search/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY search/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/search/app/main.py
+++ b/jobsy/search/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Search Service -- Elasticsearch-powered full-text search."""
 
 import asyncio
-import logging
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI

--- a/jobsy/shared/logging.py
+++ b/jobsy/shared/logging.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 
 
 class JSONFormatter(logging.Formatter):
@@ -11,7 +11,7 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_entry = {
-            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "timestamp": datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat(),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),

--- a/jobsy/storage/Dockerfile
+++ b/jobsy/storage/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY storage/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY storage/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/swipes/Dockerfile
+++ b/jobsy/swipes/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY shared /shared
 RUN pip install --no-cache-dir /shared
 
-COPY requirements.txt .
+COPY swipes/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ ./app/
+COPY swipes/app/ ./app/
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/jobsy/swipes/app/main.py
+++ b/jobsy/swipes/app/main.py
@@ -1,7 +1,6 @@
 """Jobsy Swipe Service."""
 
 import asyncio
-import logging
 import signal
 from contextlib import asynccontextmanager
 


### PR DESCRIPTION
## Summary
This PR fixes all Railway deployment failures and GitHub Actions linter errors.

### Railway Dockerfile Fixes (15 files)
All 15 backend service Dockerfiles updated to use service-specific COPY paths since the build context is `/jobsy` (not the service subdirectory):
- `COPY requirements.txt .` → `COPY {service}/requirements.txt .`
- `COPY app/ ./app/` → `COPY {service}/app/ ./app/`

### Ruff Linter Fixes (16 files)
- **F401**: Removed 13 unused `import logging` + 1 unused `import contextlib`
- **B904**: Added `from None` to `raise HTTPException` in gateway proxy
- **UP017**: Modernized `timezone.utc` → `datetime.UTC` in shared/logging.py
- **E501**: Reformatted long lines in proxy.py

### Testing
- `ruff check .` passes clean (0 errors)
- All 94 pytest tests pass