### PR TITLE
fix: properly install shared package in Dockerfiles

### DIFF
--- a/jobsy/admin/Dockerfile
+++ b/jobsy/admin/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY admin/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/advertising/Dockerfile
+++ b/jobsy/advertising/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY advertising/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/chat/Dockerfile
+++ b/jobsy/chat/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY chat/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/gateway/Dockerfile
+++ b/jobsy/gateway/Dockerfile
@@ -4,8 +4,9 @@ RUN adduser --disabled-password --gecos "" appuser
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY gateway/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/geoshard/Dockerfile
+++ b/jobsy/geoshard/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY geoshard/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/listings/Dockerfile
+++ b/jobsy/listings/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY listings/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/matches/Dockerfile
+++ b/jobsy/matches/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY matches/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/notifications/Dockerfile
+++ b/jobsy/notifications/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY notifications/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/payments/Dockerfile
+++ b/jobsy/payments/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY payments/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/profiles/Dockerfile
+++ b/jobsy/profiles/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY profiles/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/recommendations/Dockerfile
+++ b/jobsy/recommendations/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY recommendations/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/requirements-test.txt
+++ b/jobsy/requirements-test.txt
@@ -1,10 +1,11 @@
+# Test framework
 pytest>=7.4.0
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
 httpx>=0.25.0
 aiosqlite>=0.19.0
 factory-boy>=3.3.0
-# Shared library dependencies (needed by conftest.py and service tests)
+# Shared library dependencies
 sqlalchemy[asyncio]>=2.0.23
 asyncpg>=0.29.0
 GeoAlchemy2>=0.14.0
@@ -14,6 +15,19 @@ python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 aio-pika>=9.3.0
 python-dotenv>=1.0.0
-# Service dependencies (needed by service app imports in tests)
+# Core service framework
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
+# Service-specific dependencies
+redis>=5.0.0
+stripe>=7.0.0
+websockets>=12.0
+email-validator>=2.1.0
+prometheus-fastapi-instrumentator>=6.0
+s2sphere>=0.2.5
+pygeohash>=1.2.0
+firebase-admin>=6.2.0
+elasticsearch[async]>=8.11.0
+boto3>=1.34.0
+Pillow>=10.1.0
+python-multipart>=0.0.6

--- a/jobsy/requirements-test.txt
+++ b/jobsy/requirements-test.txt
@@ -4,3 +4,16 @@ pytest-cov>=4.1.0
 httpx>=0.25.0
 aiosqlite>=0.19.0
 factory-boy>=3.3.0
+# Shared library dependencies (needed by conftest.py and service tests)
+sqlalchemy[asyncio]>=2.0.23
+asyncpg>=0.29.0
+GeoAlchemy2>=0.14.0
+pydantic>=2.5.0
+pydantic-settings>=2.1.0
+python-jose[cryptography]>=3.3.0
+passlib[bcrypt]>=1.7.4
+aio-pika>=9.3.0
+python-dotenv>=1.0.0
+# Service dependencies (needed by service app imports in tests)
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0

--- a/jobsy/reviews/Dockerfile
+++ b/jobsy/reviews/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY reviews/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/search/Dockerfile
+++ b/jobsy/search/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY search/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/storage/Dockerfile
+++ b/jobsy/storage/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY storage/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/jobsy/swipes/Dockerfile
+++ b/jobsy/swipes/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY shared /shared
-RUN pip install --no-cache-dir /shared
+COPY shared/pyproject.toml /build/pyproject.toml
+COPY shared/ /build/shared/
+RUN pip install --no-cache-dir /build
 
 COPY swipes/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
The shared package has a flat directory structure where pyproject.toml sits alongside __init__.py. setuptools expects pyproject.toml at the project root with the actual package in a subdirectory.

Fix: Create proper nested structure during Docker build:
  /build/pyproject.toml
  /build/shared/__init__.py, config.py, database.py, etc.

This ensures 'pip install /build' correctly installs the 'shared' Python module, resolving the 'ModuleNotFoundError: No module named shared' crash on service startup.