### PR TITLE
fix: healthcheck route ordering and Python 3.11 logging compatibility

### DIFF
--- a/jobsy/admin/app/main.py
+++ b/jobsy/admin/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Admin", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "admin"}
+
+
+app.include_router(router)

--- a/jobsy/advertising/app/main.py
+++ b/jobsy/advertising/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Advertising", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "advertising"}
+
+
+app.include_router(router)

--- a/jobsy/chat/app/main.py
+++ b/jobsy/chat/app/main.py
@@ -28,14 +28,14 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Chat", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
+@app.get("/health")
+async def health():
+    return {"status": "ok", "service": "chat"}
+
+
 app.include_router(router)
 
 
 @app.websocket("/ws/{conversation_id}")
 async def websocket_endpoint(websocket, conversation_id: str):
     await chat_websocket(websocket, conversation_id)
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok", "service": "chat"}

--- a/jobsy/geoshard/app/main.py
+++ b/jobsy/geoshard/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Geoshard", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "geoshard"}
+
+
+app.include_router(router)

--- a/jobsy/listings/app/main.py
+++ b/jobsy/listings/app/main.py
@@ -27,9 +27,11 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Listings", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
 
 
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "listings"}
+
+
+app.include_router(router)

--- a/jobsy/matches/app/main.py
+++ b/jobsy/matches/app/main.py
@@ -28,9 +28,11 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Matches", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
 
 
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "matches"}
+
+
+app.include_router(router)

--- a/jobsy/notifications/app/main.py
+++ b/jobsy/notifications/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Notifications", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "notifications"}
+
+
+app.include_router(router)

--- a/jobsy/payments/app/main.py
+++ b/jobsy/payments/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Payments", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "payments"}
+
+
+app.include_router(router)

--- a/jobsy/profiles/app/main.py
+++ b/jobsy/profiles/app/main.py
@@ -27,9 +27,11 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Profiles", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
 
 
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "profiles"}
+
+
+app.include_router(router)

--- a/jobsy/recommendations/app/main.py
+++ b/jobsy/recommendations/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Recommendations", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "recommendations"}
+
+
+app.include_router(router)

--- a/jobsy/reviews/app/main.py
+++ b/jobsy/reviews/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Reviews", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "reviews"}
+
+
+app.include_router(router)

--- a/jobsy/search/app/main.py
+++ b/jobsy/search/app/main.py
@@ -28,9 +28,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Search", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "search"}
+
+
+app.include_router(router)

--- a/jobsy/shared/logging.py
+++ b/jobsy/shared/logging.py
@@ -11,7 +11,7 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_entry = {
-            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),  # noqa: UP017 - Docker images use Python 3.11 where datetime.UTC is unavailable
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),

--- a/jobsy/shared/logging.py
+++ b/jobsy/shared/logging.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class JSONFormatter(logging.Formatter):
@@ -11,7 +11,7 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_entry = {
-            "timestamp": datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat(),
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),

--- a/jobsy/storage/app/main.py
+++ b/jobsy/storage/app/main.py
@@ -32,9 +32,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Storage", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "storage"}
+
+
+app.include_router(router)

--- a/jobsy/swipes/app/main.py
+++ b/jobsy/swipes/app/main.py
@@ -27,9 +27,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Swipes", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
-app.include_router(router)
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "swipes"}
+
+
+app.include_router(router)


### PR DESCRIPTION
## Changes

### 1. Health endpoint route ordering (all 15 services)
Move `@app.get('/health')` registration **before** `app.include_router(router)` in all services.

**Root cause:** Services with bare `/{id}` path parameters (listings, matches, profiles) had their healthcheck requests intercepted by the catch-all route, which triggered a DB query and returned 500.

### 2. Python 3.11 logging fix (`shared/logging.py`)
Replace `datetime.UTC` (attribute of `datetime.datetime`, only in Python 3.12+) with `timezone.utc` for compatibility with the `python:3.11-slim` Docker base image.

**Root cause:** The JSON log formatter crashed with `AttributeError: type object 'datetime.datetime' has no attribute 'UTC'` on every request, causing the middleware to return 500 Internal Server Error.

### Impact
These two bugs combined caused listings, matches, and profiles to fail Railway healthchecks. All other services are preventively fixed for route ordering.