### PR TITLE
fix: add missing httpx dependency to matches service

### DIFF
--- a/jobsy/matches/requirements.txt
+++ b/jobsy/matches/requirements.txt
@@ -6,4 +6,5 @@ pydantic>=2.5.0
 pydantic-settings>=2.1.0
 python-jose[cryptography]>=3.3.0
 aio-pika>=9.3.0
+httpx>=0.25.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
The matches service imports httpx in consumer.py for making HTTP calls to the listings service, but httpx was not listed in requirements.txt. This causes an ImportError at startup, preventing the service from starting and failing the healthcheck.