### PR TITLE
fix: make all services production-ready for Railway deployment

### DIFF
--- a/jobsy/admin/Dockerfile
+++ b/jobsy/admin/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY admin/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/advertising/Dockerfile
+++ b/jobsy/advertising/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY advertising/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/chat/Dockerfile
+++ b/jobsy/chat/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY chat/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/chat/app/main.py
+++ b/jobsy/chat/app/main.py
@@ -28,6 +28,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Chat", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "chat"}

--- a/jobsy/chat/app/websocket.py
+++ b/jobsy/chat/app/websocket.py
@@ -146,6 +146,7 @@ async def chat_websocket(websocket: WebSocket, conversation_id: str):
         _start_redis_listener(conversation_id, websocket, user_id)
     )
 
+    redis_client = await _get_redis()
     try:
         while True:
             data = await websocket.receive_json()
@@ -161,9 +162,7 @@ async def chat_websocket(websocket: WebSocket, conversation_id: str):
             # Broadcast via Redis pub/sub (reaches all instances including local).
             # The Redis listener filters out messages from the sender, so each
             # participant receives the message exactly once.
-            redis_client = await _get_redis()
             await redis_client.publish(f"chat:{conversation_id}", json.dumps(msg))
-            await redis_client.close()
 
             # Emit event for notifications service
             await publish_event("message.new", {
@@ -177,6 +176,7 @@ async def chat_websocket(websocket: WebSocket, conversation_id: str):
     except Exception:
         logger.exception("WebSocket error for user %s in conversation %s", user_id, conversation_id)
     finally:
+        await redis_client.close()
         listener_task.cancel()
         if conversation_id in _connections:
             _connections[conversation_id].pop(user_id, None)

--- a/jobsy/gateway/Dockerfile
+++ b/jobsy/gateway/Dockerfile
@@ -15,5 +15,4 @@ COPY gateway/app/ ./app/
 
 USER appuser
 
-
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/gateway/app/main.py
+++ b/jobsy/gateway/app/main.py
@@ -90,7 +90,7 @@ app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(proxy_router)
 
-CHAT_SERVICE_URL = os.getenv("CHAT_SERVICE_URL", "http://chat:8000")
+CHAT_SERVICE_URL = os.getenv("CHAT_SERVICE_URL", "http://chat.railway.internal:8080")
 
 
 @app.websocket("/ws/chat/{conversation_id}")

--- a/jobsy/gateway/app/routes/auth.py
+++ b/jobsy/gateway/app/routes/auth.py
@@ -25,7 +25,9 @@ from ..models import User
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-# Simple in-memory sliding window for auth endpoint rate limiting
+# Simple in-memory sliding window for auth endpoint rate limiting.
+# NOTE: This is per-instance only. In a multi-instance Railway deployment,
+# the Redis-based rate limiter in middleware handles cross-instance limiting.
 _auth_attempts: dict[str, list[float]] = defaultdict(list)
 
 
@@ -46,8 +48,8 @@ async def _check_auth_rate_limit(request: Request) -> None:
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 async def register(request: Request, data: UserCreate, db: AsyncSession = Depends(get_db)):
-    await _check_auth_rate_limit(request)
     """Register a new user with phone number and password."""
+    await _check_auth_rate_limit(request)
     result = await db.execute(select(User).where(User.phone == data.phone))
     if result.scalar_one_or_none():
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Phone number already registered")
@@ -77,8 +79,8 @@ async def register(request: Request, data: UserCreate, db: AsyncSession = Depend
 
 @router.post("/login", response_model=TokenResponse)
 async def login(request: Request, data: UserLogin, db: AsyncSession = Depends(get_db)):
-    await _check_auth_rate_limit(request)
     """Login with phone and password."""
+    await _check_auth_rate_limit(request)
     result = await db.execute(select(User).where(User.phone == data.phone))
     user = result.scalar_one_or_none()
 

--- a/jobsy/geoshard/Dockerfile
+++ b/jobsy/geoshard/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY geoshard/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/listings/Dockerfile
+++ b/jobsy/listings/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY listings/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/matches/Dockerfile
+++ b/jobsy/matches/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY matches/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/matches/app/consumer.py
+++ b/jobsy/matches/app/consumer.py
@@ -21,7 +21,7 @@ from .models import Match
 
 logger = logging.getLogger(__name__)
 
-LISTINGS_SERVICE_URL = os.getenv("LISTINGS_SERVICE_URL", "http://listings:8000")
+LISTINGS_SERVICE_URL = os.getenv("LISTINGS_SERVICE_URL", "http://listings.railway.internal:8080")
 
 
 # Local mirror of the swipes table for direct DB queries (same database).

--- a/jobsy/notifications/Dockerfile
+++ b/jobsy/notifications/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY notifications/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/notifications/app/main.py
+++ b/jobsy/notifications/app/main.py
@@ -27,6 +27,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Notifications", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "notifications"}

--- a/jobsy/payments/Dockerfile
+++ b/jobsy/payments/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY payments/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/profiles/Dockerfile
+++ b/jobsy/profiles/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY profiles/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/profiles/app/routes.py
+++ b/jobsy/profiles/app/routes.py
@@ -65,6 +65,7 @@ async def update_or_create_profile(
             user_id=user_id,
             geohash=geohash,
             parish=parish,
+            is_verified=False,
             is_active=True,
             created_at=now,
             updated_at=now,

--- a/jobsy/profiles/app/schemas.py
+++ b/jobsy/profiles/app/schemas.py
@@ -45,6 +45,7 @@ class ProfileResponse(BaseModel):
     is_provider: bool
     rating_avg: Decimal
     rating_count: int
+    is_verified: bool = False
     is_active: bool
     created_at: datetime
 

--- a/jobsy/recommendations/Dockerfile
+++ b/jobsy/recommendations/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY recommendations/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/recommendations/app/routes.py
+++ b/jobsy/recommendations/app/routes.py
@@ -19,9 +19,9 @@ from .ranker import rank_candidate
 
 router = APIRouter(tags=["recommendations"])
 
-GEOSHARD_URL = os.getenv("GEOSHARD_SERVICE_URL", "http://geoshard:8000")
-LISTINGS_URL = os.getenv("LISTINGS_SERVICE_URL", "http://listings:8000")
-PROFILES_URL = os.getenv("PROFILES_SERVICE_URL", "http://profiles:8000")
+GEOSHARD_URL = os.getenv("GEOSHARD_SERVICE_URL", "http://geoshard.railway.internal:8080")
+LISTINGS_URL = os.getenv("LISTINGS_SERVICE_URL", "http://listings.railway.internal:8080")
+PROFILES_URL = os.getenv("PROFILES_SERVICE_URL", "http://profiles.railway.internal:8080")
 
 
 def _get_user_id(request: Request) -> str:

--- a/jobsy/reviews/Dockerfile
+++ b/jobsy/reviews/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY reviews/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/search/Dockerfile
+++ b/jobsy/search/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY search/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/search/app/main.py
+++ b/jobsy/search/app/main.py
@@ -28,6 +28,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Search", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "search"}

--- a/jobsy/shared/models/listing.py
+++ b/jobsy/shared/models/listing.py
@@ -39,6 +39,9 @@ class ListingResponse(BaseModel):
     budget_min: Decimal | None
     budget_max: Decimal | None
     currency: str
+    latitude: float | None = None
+    longitude: float | None = None
+    geohash: str | None = None
     parish: str | None
     address_text: str | None
     status: str

--- a/jobsy/storage/Dockerfile
+++ b/jobsy/storage/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY storage/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/storage/app/main.py
+++ b/jobsy/storage/app/main.py
@@ -32,6 +32,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Jobsy Storage", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok", "service": "storage"}

--- a/jobsy/swipes/Dockerfile
+++ b/jobsy/swipes/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
+
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY swipes/app/ ./app/
 
-CMD uvicorn app.main:app --host :: --port ${PORT:-8000}
+USER appuser
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
- Fix all 15 Dockerfiles: bind to 0.0.0.0 instead of :: (IPv6), use
  exec-form CMD, and add non-root appuser for security
- Fix hardcoded service URL defaults to use Railway internal networking
  (*.railway.internal:8080) in gateway WebSocket, matches consumer, and
  recommendations service
- Fix chat WebSocket creating new Redis client per message (connection
  exhaustion) — reuse single client for connection lifetime
- Add missing is_verified field to ProfileResponse schema and set
  explicit default in profile creation route
- Add missing latitude/longitude/geohash fields to ListingResponse schema
- Fix misplaced docstrings in auth register/login routes (placed after
  rate limit call instead of as first statement)
- Add cross-instance scaling note to in-memory auth rate limiter
- Fix missing blank lines before health check decorators in chat,
  notifications, search, and storage services

All 94 tests pass, ruff linter clean.

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU