### PR TITLE
fix: align mobile frontend API calls with backend route contracts

### DIFF
--- a/jobsy/mobile/src/api/ads.ts
+++ b/jobsy/mobile/src/api/ads.ts
@@ -1,13 +1,11 @@
 import { api } from "./client";
 
 export interface Ad {
-  id: string;
   campaign_id: string;
   title: string;
   description: string;
   image_url: string;
   click_url: string;
-  placement: string;
 }
 
 /**
@@ -19,10 +17,10 @@ export async function fetchAd(
   category?: string,
 ): Promise<Ad | null> {
   try {
-    const res = await api.get<Ad>(`/api/ads/serve/${placement}`, {
+    const res = await api.get<{ ad: Ad | null; placement: string }>(`/api/ads/serve/${placement}`, {
       params: { parish, category },
     });
-    return res.data;
+    return res.data.ad;
   } catch {
     // No ad available or server error, silently return null
     return null;
@@ -38,9 +36,8 @@ export async function recordImpression(
   placementId?: string,
 ): Promise<void> {
   try {
-    await api.post("/api/ads/impressions", {
-      campaign_id: campaignId,
-      placement_id: placementId,
+    await api.post("/api/ads/impression", null, {
+      params: { campaign_id: campaignId, placement_id: placementId },
     });
   } catch {
     // Silently ignore, impression tracking should not block UI

--- a/jobsy/mobile/src/api/listings.ts
+++ b/jobsy/mobile/src/api/listings.ts
@@ -10,6 +10,9 @@ export interface Listing {
   budget_min: number | null;
   budget_max: number | null;
   currency: string;
+  latitude: number | null;
+  longitude: number | null;
+  geohash: string | null;
   parish: string | null;
   address_text: string | null;
   status: string;

--- a/jobsy/mobile/src/api/matches.ts
+++ b/jobsy/mobile/src/api/matches.ts
@@ -26,8 +26,6 @@ export async function updateMatchStatus(
   id: string,
   newStatus: "completed" | "cancelled"
 ): Promise<{ id: string; status: string }> {
-  const res = await api.put(`/api/matches/${id}/status`, null, {
-    params: { new_status: newStatus },
-  });
+  const res = await api.put(`/api/matches/${id}/status`, { status: newStatus });
   return res.data;
 }

--- a/jobsy/mobile/src/api/profiles.ts
+++ b/jobsy/mobile/src/api/profiles.ts
@@ -14,6 +14,7 @@ export interface Profile {
   is_provider: boolean;
   rating_avg: number;
   rating_count: number;
+  is_verified: boolean;
   is_active: boolean;
   created_at: string;
 }
@@ -52,6 +53,6 @@ export async function getNearbyProfiles(params: {
   radius_km?: number;
   limit?: number;
 }): Promise<Profile[]> {
-  const res = await api.get<Profile[]>("/api/profiles/nearby", { params });
+  const res = await api.get<Profile[]>("/api/profiles/nearby/search", { params });
   return res.data;
 }

--- a/jobsy/mobile/src/api/storage.ts
+++ b/jobsy/mobile/src/api/storage.ts
@@ -1,6 +1,6 @@
 import { api } from "./client";
 
-export async function uploadFile(uri: string, bucket = "listings"): Promise<{ url: string }> {
+export async function uploadFile(uri: string, folder = "listings"): Promise<{ url: string }> {
   const formData = new FormData();
 
   const filename = uri.split("/").pop() || "photo.jpg";
@@ -12,15 +12,15 @@ export async function uploadFile(uri: string, bucket = "listings"): Promise<{ ur
     name: filename,
     type,
   } as unknown as Blob);
-  formData.append("bucket", bucket);
 
   const res = await api.post("/api/storage/upload", formData, {
     headers: { "Content-Type": "multipart/form-data" },
+    params: { folder },
   });
   return res.data;
 }
 
-export async function getPresignedUrl(key: string, bucket = "listings"): Promise<string> {
-  const res = await api.get("/api/storage/presigned-url", { params: { key, bucket } });
+export async function getPresignedUrl(folder: string, contentType: string): Promise<string> {
+  const res = await api.post("/api/storage/presigned", { folder, content_type: contentType });
   return res.data.url;
 }

--- a/jobsy/mobile/src/components/AdBanner.tsx
+++ b/jobsy/mobile/src/components/AdBanner.tsx
@@ -34,7 +34,7 @@ export default function AdBanner({ placement, parish, category }: AdBannerProps)
   // Track impression once when ad becomes visible
   useEffect(() => {
     if (ad && !impressionTracked) {
-      recordImpression(ad.campaign_id, ad.id);
+      recordImpression(ad.campaign_id);
       setImpressionTracked(true);
     }
   }, [ad, impressionTracked]);

--- a/jobsy/mobile/src/hooks/useWebSocket.ts
+++ b/jobsy/mobile/src/hooks/useWebSocket.ts
@@ -28,7 +28,7 @@ export function useWebSocket(conversationId: string | null) {
     const token = await SecureStore.getItemAsync("access_token");
     if (!token) return;
 
-    const url = `${WS_URL}/ws/${conversationId}?token=${token}`;
+    const url = `${WS_URL}/ws/chat/${conversationId}?token=${token}`;
     const socket = new WebSocket(url);
 
     socket.onopen = () => {


### PR DESCRIPTION
- Fix WebSocket path: add missing /chat segment so connections reach the gateway's /ws/chat/{id} route instead of 404ing on /ws/{id}
- Fix match status update: send status in request body instead of query param to match backend's MatchStatusUpdate Pydantic model
- Fix nearby profiles: call /nearby/search to match backend route (was calling /nearby which doesn't exist)
- Fix ad impressions: use correct path /impression (singular) and send campaign_id/placement_id as query params instead of JSON body
- Fix ad serve response: unwrap {ad, placement} wrapper object and update Ad interface to match backend response shape (no id field)
- Fix AdBanner component: remove reference to non-existent ad.id
- Add is_verified field to frontend Profile interface to match backend ProfileResponse
- Add latitude/longitude/geohash fields to frontend Listing interface to match backend ListingResponse
- Fix storage upload: send folder as query param instead of FormData field (backend reads Query param, ignores FormData "bucket")
- Fix storage presigned URL: use POST /presigned with {folder, content_type} body instead of GET /presigned-url with query params

TypeScript and ESLint clean. All 94 backend tests pass.

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU