### PR TITLE
fix: resolve bot crash on Railway from DB write permission error

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -8,6 +8,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+RUN chown -R appuser:appuser /app
 
 USER appuser
 

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -26,6 +26,7 @@ import asyncio
 import datetime
 import logging
 import functools
+import sys
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import Application, CommandHandler, CallbackQueryHandler, ContextTypes
 from telegram.constants import ParseMode
@@ -467,12 +468,18 @@ async def post_init(application):
 
 def run_bot():
     """Initialize and run the Telegram bot."""
-    if not TELEGRAM_BOT_TOKEN:
-        print("ERROR: TELEGRAM_BOT_TOKEN not set. Check your .env file.")
-        return
+    logger.info("Deal Bot starting up...")
 
-    init_db()
-    logger.info("Database initialized.")
+    if not TELEGRAM_BOT_TOKEN:
+        logger.error("TELEGRAM_BOT_TOKEN not set. Check your environment variables.")
+        sys.exit(1)
+
+    try:
+        init_db()
+        logger.info("Database initialized.")
+    except Exception as e:
+        logger.error("Database initialization failed: %s", e)
+        sys.exit(1)
 
     app = Application.builder().token(TELEGRAM_BOT_TOKEN).post_init(post_init).build()
 


### PR DESCRIPTION
The Dockerfile adds a non-root appuser but never gave it write access to /app. When init_db() tries to create deals.db, SQLite fails with a permission error.

- Add chown for appuser in bot/Dockerfile so DB can be created
- Fail fast with sys.exit(1) when TELEGRAM_BOT_TOKEN is missing
- Wrap init_db() in try/except with clear error logging for Railway

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU