### PR TITLE
fix: add production guards for RABBITMQ_URL and REDIS_URL to prevent …

### DIFF
--- a/jobsy/railway.toml
+++ b/jobsy/railway.toml
@@ -10,7 +10,8 @@ restartPolicyMaxRetries = 5
 [environment]
 # These are overridden per-service in Railway dashboard
 # Listed here as documentation of required environment variables
+# All four are REQUIRED in production — services will refuse to start without them.
 # DATABASE_URL = "provided by Railway Postgres plugin"
 # REDIS_URL = "provided by Railway Redis plugin"
-# RABBITMQ_URL = "provided by Railway or CloudAMQP"
+# RABBITMQ_URL = "REQUIRED: provide via CloudAMQP plugin or self-hosted RabbitMQ service URL"
 # JWT_SECRET = "set in Railway secrets"

--- a/jobsy/shared/config.py
+++ b/jobsy/shared/config.py
@@ -12,8 +12,19 @@ DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://jobsy:localdev@lo
 # requires 'postgresql+asyncpg://'. Auto-convert for compatibility.
 if DATABASE_URL.startswith("postgresql://"):
     DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+REDIS_URL = os.getenv("REDIS_URL", "")
+if not REDIS_URL:
+    if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
+        raise RuntimeError("REDIS_URL environment variable must be set in production")
+    else:
+        REDIS_URL = "redis://localhost:6379/0"
+
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "")
+if not RABBITMQ_URL:
+    if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
+        raise RuntimeError("RABBITMQ_URL environment variable must be set in production")
+    else:
+        RABBITMQ_URL = "amqp://guest:guest@localhost:5672/"
 
 _jwt_secret = os.getenv("JWT_SECRET", "")
 if not _jwt_secret:


### PR DESCRIPTION
…silent localhost fallback

Services were connecting to amqp://guest:guest@localhost:5672/ in production because RABBITMQ_URL was not set in Railway, causing 1,200+ connection refused errors every 15 minutes across 7 services. Now raises RuntimeError at startup when these variables are missing in production, matching existing JWT_SECRET behavior.

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU