### PR TITLE
fix: harden all services for Railway production deployment

### DIFF
--- a/jobsy/admin/app/main.py
+++ b/jobsy/admin/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Admin", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "admin"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "admin"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "admin", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/advertising/app/main.py
+++ b/jobsy/advertising/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Advertising", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "advertising"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "advertising"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "advertising", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/chat/app/main.py
+++ b/jobsy/chat/app/main.py
@@ -4,8 +4,10 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -32,7 +34,15 @@ setup_middleware(app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "chat"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "chat"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "chat", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/gateway/app/routes/health.py
+++ b/jobsy/gateway/app/routes/health.py
@@ -1,10 +1,18 @@
 """Health check endpoint for Railway."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 router = APIRouter(tags=["health"])
 
 
 @router.get("/health", summary="Gateway health check", response_description="Service status")
-async def health_check():
-    return {"status": "ok", "service": "gateway"}
+async def health_check(request: Request):
+    status = {"status": "ok", "service": "gateway"}
+    redis = getattr(request.app.state, "redis", None)
+    if redis:
+        try:
+            await redis.ping()
+        except Exception:
+            status["status"] = "degraded"
+            status["redis"] = "unavailable"
+    return status

--- a/jobsy/geoshard/app/main.py
+++ b/jobsy/geoshard/app/main.py
@@ -4,8 +4,10 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Geoshard", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "geoshard"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "geoshard"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "geoshard", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/listings/app/main.py
+++ b/jobsy/listings/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -31,7 +33,15 @@ setup_middleware(app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "listings"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "listings"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "listings", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/matches/app/main.py
+++ b/jobsy/matches/app/main.py
@@ -4,8 +4,10 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -32,7 +34,15 @@ setup_middleware(app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "matches"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "matches"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "matches", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/notifications/app/main.py
+++ b/jobsy/notifications/app/main.py
@@ -4,8 +4,10 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -31,7 +33,15 @@ setup_middleware(app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "notifications"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "notifications"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "notifications", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/payments/app/main.py
+++ b/jobsy/payments/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Payments", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "payments"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "payments"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "payments", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/profiles/app/main.py
+++ b/jobsy/profiles/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -31,7 +33,15 @@ setup_middleware(app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "profiles"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "profiles"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "profiles", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/railway.toml
+++ b/jobsy/railway.toml
@@ -10,8 +10,9 @@ restartPolicyMaxRetries = 5
 [environment]
 # These are overridden per-service in Railway dashboard
 # Listed here as documentation of required environment variables
-# All four are REQUIRED in production — services will refuse to start without them.
+# All five are REQUIRED in production — services will refuse to start without them.
 # DATABASE_URL = "provided by Railway Postgres plugin"
 # REDIS_URL = "provided by Railway Redis plugin"
 # RABBITMQ_URL = "REQUIRED: provide via CloudAMQP plugin or self-hosted RabbitMQ service URL"
+# ELASTICSEARCH_URL = "REQUIRED for search service: provide via Elasticsearch plugin or hosted URL"
 # JWT_SECRET = "set in Railway secrets"

--- a/jobsy/recommendations/app/main.py
+++ b/jobsy/recommendations/app/main.py
@@ -4,8 +4,10 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Recommendations", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "recommendations"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "recommendations"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "recommendations", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/reviews/Dockerfile
+++ b/jobsy/reviews/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-slim
 
+RUN adduser --disabled-password --gecos "" appuser
 WORKDIR /app
 
 COPY shared/pyproject.toml /build/pyproject.toml
@@ -11,4 +12,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY reviews/app/ ./app/
 
+USER appuser
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/jobsy/reviews/app/main.py
+++ b/jobsy/reviews/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Reviews", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "reviews"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "reviews"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "reviews", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)

--- a/jobsy/search/app/elasticsearch_client.py
+++ b/jobsy/search/app/elasticsearch_client.py
@@ -14,9 +14,10 @@ from typing import Any
 
 from elasticsearch import AsyncElasticsearch
 
+from shared.config import ELASTICSEARCH_URL
+
 logger = logging.getLogger(__name__)
 
-ES_URL = os.getenv("ELASTICSEARCH_URL", "http://elasticsearch:9200")
 ES_USERNAME = os.getenv("ELASTICSEARCH_USERNAME", "")
 ES_PASSWORD = os.getenv("ELASTICSEARCH_PASSWORD", "")
 
@@ -68,7 +69,7 @@ async def get_client() -> AsyncElasticsearch | None:
         return _client
 
     try:
-        kwargs: dict[str, Any] = {"hosts": [ES_URL]}
+        kwargs: dict[str, Any] = {"hosts": [ELASTICSEARCH_URL]}
         if ES_USERNAME:
             kwargs["basic_auth"] = (ES_USERNAME, ES_PASSWORD)
 
@@ -77,7 +78,7 @@ async def get_client() -> AsyncElasticsearch | None:
         logger.info("Connected to Elasticsearch %s", info["version"]["number"])
         return _client
     except Exception:
-        logger.warning("Elasticsearch not available at %s", ES_URL)
+        logger.warning("Elasticsearch not available at %s", ELASTICSEARCH_URL)
         _client = None
         return None
 

--- a/jobsy/search/app/main.py
+++ b/jobsy/search/app/main.py
@@ -4,12 +4,13 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
 from .consumer import start_consumers
-from .elasticsearch_client import close_client, ensure_indices
+from .elasticsearch_client import close_client, ensure_indices, get_client
 from .routes import router
 
 setup_json_logging()
@@ -32,7 +33,13 @@ setup_middleware(app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "search"}
+    client = await get_client()
+    if client:
+        return {"status": "ok", "service": "search"}
+    return JSONResponse(
+        {"status": "degraded", "service": "search", "error": "elasticsearch unavailable"},
+        status_code=503,
+    )
 
 
 app.include_router(router)

--- a/jobsy/shared/config.py
+++ b/jobsy/shared/config.py
@@ -7,10 +7,15 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://jobsy:localdev@localhost:5432/jobsy")
-# Railway provides DATABASE_URL with 'postgresql://' prefix, but SQLAlchemy async
-# requires 'postgresql+asyncpg://'. Auto-convert for compatibility.
-if DATABASE_URL.startswith("postgresql://"):
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+if not DATABASE_URL:
+    if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
+        raise RuntimeError("DATABASE_URL environment variable must be set in production")
+    else:
+        DATABASE_URL = "postgresql+asyncpg://jobsy:localdev@localhost:5432/jobsy"
+elif DATABASE_URL.startswith("postgresql://"):
+    # Railway provides DATABASE_URL with 'postgresql://' prefix, but SQLAlchemy async
+    # requires 'postgresql+asyncpg://'. Auto-convert for compatibility.
     DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 REDIS_URL = os.getenv("REDIS_URL", "")
 if not REDIS_URL:
@@ -44,6 +49,14 @@ JWT_REFRESH_EXPIRY_DAYS = int(os.getenv("JWT_REFRESH_EXPIRY_DAYS", "30"))
 # OAuth
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
 APPLE_BUNDLE_ID = os.getenv("APPLE_BUNDLE_ID", "com.jobsy.app")
+
+# Elasticsearch
+ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "")
+if not ELASTICSEARCH_URL:
+    if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
+        raise RuntimeError("ELASTICSEARCH_URL environment variable must be set in production")
+    else:
+        ELASTICSEARCH_URL = "http://localhost:9200"
 
 # Twilio SMS
 TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID", "")

--- a/jobsy/swipes/app/main.py
+++ b/jobsy/swipes/app/main.py
@@ -5,8 +5,10 @@ import signal
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
-from shared.database import init_db
+from shared.database import async_session_factory, init_db
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
 
@@ -29,7 +31,15 @@ app = FastAPI(title="Jobsy Swipes", version="0.1.0", lifespan=lifespan)
 setup_middleware(app)
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "swipes"}
+    try:
+        async with async_session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "service": "swipes"}
+    except Exception:
+        return JSONResponse(
+            {"status": "degraded", "service": "swipes", "error": "database unavailable"},
+            status_code=503,
+        )
 
 
 app.include_router(router)


### PR DESCRIPTION
- Add production guards for DATABASE_URL and ELASTICSEARCH_URL in shared/config.py (fail fast instead of silent localhost fallback)
- Add non-root appuser to reviews/Dockerfile (was only service running as root)
- Add dependency connectivity checks to all 14 health endpoints: DB-backed services verify PostgreSQL, gateway verifies Redis, search verifies Elasticsearch. Returns 503 when degraded so Railway can detect and restart unhealthy services.
- Centralize ELASTICSEARCH_URL config in shared/config.py (was hardcoded to docker-compose hostname in search service)
- Update railway.toml to document ELASTICSEARCH_URL as required

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU