### PR TITLE
fix: stop crashing all services when optional infra vars are missing

### DIFF
--- a/jobsy/search/app/elasticsearch_client.py
+++ b/jobsy/search/app/elasticsearch_client.py
@@ -68,6 +68,10 @@ async def get_client() -> AsyncElasticsearch | None:
     if _client is not None:
         return _client
 
+    if not ELASTICSEARCH_URL:
+        logger.warning("ELASTICSEARCH_URL not configured, search unavailable")
+        return None
+
     try:
         kwargs: dict[str, Any] = {"hosts": [ELASTICSEARCH_URL]}
         if ES_USERNAME:

--- a/jobsy/shared/config.py
+++ b/jobsy/shared/config.py
@@ -20,14 +20,14 @@ elif DATABASE_URL.startswith("postgresql://"):
 REDIS_URL = os.getenv("REDIS_URL", "")
 if not REDIS_URL:
     if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
-        raise RuntimeError("REDIS_URL environment variable must be set in production")
+        logging.warning("REDIS_URL not set in production — Redis features will be unavailable")
     else:
         REDIS_URL = "redis://localhost:6379/0"
 
 RABBITMQ_URL = os.getenv("RABBITMQ_URL", "")
 if not RABBITMQ_URL:
     if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
-        raise RuntimeError("RABBITMQ_URL environment variable must be set in production")
+        logging.warning("RABBITMQ_URL not set in production — event publishing will be disabled")
     else:
         RABBITMQ_URL = "amqp://guest:guest@localhost:5672/"
 
@@ -54,7 +54,7 @@ APPLE_BUNDLE_ID = os.getenv("APPLE_BUNDLE_ID", "com.jobsy.app")
 ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "")
 if not ELASTICSEARCH_URL:
     if os.getenv("RAILWAY_ENVIRONMENT") or os.getenv("PRODUCTION"):
-        raise RuntimeError("ELASTICSEARCH_URL environment variable must be set in production")
+        logging.warning("ELASTICSEARCH_URL not set in production — search will be unavailable")
     else:
         ELASTICSEARCH_URL = "http://localhost:9200"
 

--- a/jobsy/shared/events.py
+++ b/jobsy/shared/events.py
@@ -29,6 +29,8 @@ _publish_connection: aio_pika.abc.AbstractRobustConnection | None = None
 async def get_connection():
     """Get or create a reusable RabbitMQ connection for publishing."""
     global _publish_connection
+    if not RABBITMQ_URL:
+        return None
     if _publish_connection is None or _publish_connection.is_closed:
         _publish_connection = await aio_pika.connect_robust(RABBITMQ_URL)
     return _publish_connection
@@ -50,6 +52,9 @@ async def publish_event(routing_key: str, data: dict[str, Any]) -> None:
     """
     try:
         connection = await get_connection()
+        if connection is None:
+            logger.info("RabbitMQ not configured, event %s skipped", routing_key)
+            return
         channel = await connection.channel()
         exchange = await channel.declare_exchange(EXCHANGE_NAME, aio_pika.ExchangeType.TOPIC, durable=True)
         message = aio_pika.Message(
@@ -76,6 +81,10 @@ async def consume_events(queue_name: str, routing_key: str, callback: Callable) 
     Messages that fail after MAX_RETRIES are routed to a dead-letter queue.
     The callback receives the parsed JSON data dict.
     """
+    if not RABBITMQ_URL:
+        logger.warning("RABBITMQ_URL not configured, consumer %s will not start", queue_name)
+        return
+
     while True:
         try:
             connection = await aio_pika.connect_robust(RABBITMQ_URL)


### PR DESCRIPTION
The previous fix raised RuntimeError for REDIS_URL, RABBITMQ_URL, and ELASTICSEARCH_URL when missing in production. Since shared/config.py is imported by every service, this caused ALL 14 services to crash if any single optional var was unset — even services that don't use that dependency.

Now only DATABASE_URL and JWT_SECRET (truly required) raise RuntimeError. Optional services (Redis, RabbitMQ, Elasticsearch) log a warning and degrade gracefully: events are skipped, search returns unavailable, Redis features are disabled.

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU