### PR TITLE
fix: resolve RabbitMQ DNS failures and add connection retry

### DIFF
--- a/jobsy/railway.toml
+++ b/jobsy/railway.toml
@@ -13,6 +13,8 @@ restartPolicyMaxRetries = 5
 # All five are REQUIRED in production — services will refuse to start without them.
 # DATABASE_URL = "provided by Railway Postgres plugin"
 # REDIS_URL = "provided by Railway Redis plugin"
-# RABBITMQ_URL = "REQUIRED: provide via CloudAMQP plugin or self-hosted RabbitMQ service URL"
-# ELASTICSEARCH_URL = "REQUIRED for search service: provide via Elasticsearch plugin or hosted URL"
+# RABBITMQ_URL = "provide via CloudAMQP plugin, or set RABBITMQ_HOST for Railway private networking"
+# CLOUDAMQP_URL = "auto-detected: set by CloudAMQP plugin if installed"
+# RABBITMQ_HOST = "alternative: hostname for Railway private networking (e.g. rabbitmq.railway.internal)"
+# ELASTICSEARCH_URL = "provide via Elasticsearch plugin, or set ELASTICSEARCH_HOST for private networking"
 # JWT_SECRET = "set in Railway secrets"

--- a/jobsy/shared/config.py
+++ b/jobsy/shared/config.py
@@ -32,16 +32,32 @@ elif DATABASE_URL.startswith("postgresql://"):
 REDIS_URL = os.getenv("REDIS_URL", "")
 if not REDIS_URL:
     if _is_production():
-        REDIS_URL = "redis://redis.railway.internal:6379/0"
-        logging.info("REDIS_URL not set — using Railway private networking: redis.railway.internal")
+        _redis_host = os.getenv("REDIS_HOST", "")
+        _redis_port = os.getenv("REDIS_PORT", "6379")
+        if _redis_host:
+            REDIS_URL = f"redis://{_redis_host}:{_redis_port}/0"
+            logging.info("REDIS_URL built from REDIS_HOST=%s", _redis_host)
+        else:
+            logging.warning("REDIS_URL not set in production — Redis features will be unavailable")
     else:
         REDIS_URL = "redis://localhost:6379/0"
 
-RABBITMQ_URL = os.getenv("RABBITMQ_URL", "")
+RABBITMQ_URL = os.getenv("RABBITMQ_URL") or os.getenv("CLOUDAMQP_URL", "")
 if not RABBITMQ_URL:
     if _is_production():
-        RABBITMQ_URL = "amqp://guest:guest@rabbitmq.railway.internal:5672/"
-        logging.info("RABBITMQ_URL not set — using Railway private networking: rabbitmq.railway.internal")
+        _rmq_host = os.getenv("RABBITMQ_HOST", "")
+        _rmq_port = os.getenv("RABBITMQ_PORT", "5672")
+        _rmq_user = os.getenv("RABBITMQ_USER", os.getenv("RABBITMQ_DEFAULT_USER", "guest"))
+        _rmq_pass = os.getenv("RABBITMQ_PASS", os.getenv("RABBITMQ_DEFAULT_PASS", "guest"))
+        _rmq_vhost = os.getenv("RABBITMQ_VHOST", "/")
+        if _rmq_host:
+            RABBITMQ_URL = f"amqp://{_rmq_user}:{_rmq_pass}@{_rmq_host}:{_rmq_port}/{_rmq_vhost}"
+            logging.info("RABBITMQ_URL built from RABBITMQ_HOST=%s", _rmq_host)
+        else:
+            logging.warning(
+                "RABBITMQ_URL not set in production. Set RABBITMQ_URL, CLOUDAMQP_URL, "
+                "or RABBITMQ_HOST. Event publishing will retry until available."
+            )
     else:
         RABBITMQ_URL = "amqp://guest:guest@localhost:5672/"
 
@@ -68,8 +84,13 @@ APPLE_BUNDLE_ID = os.getenv("APPLE_BUNDLE_ID", "com.jobsy.app")
 ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "")
 if not ELASTICSEARCH_URL:
     if _is_production():
-        ELASTICSEARCH_URL = "http://elasticsearch.railway.internal:9200"
-        logging.info("ELASTICSEARCH_URL not set — using Railway private networking: elasticsearch.railway.internal")
+        _es_host = os.getenv("ELASTICSEARCH_HOST", "")
+        _es_port = os.getenv("ELASTICSEARCH_PORT", "9200")
+        if _es_host:
+            ELASTICSEARCH_URL = f"http://{_es_host}:{_es_port}"
+            logging.info("ELASTICSEARCH_URL built from ELASTICSEARCH_HOST=%s", _es_host)
+        else:
+            logging.warning("ELASTICSEARCH_URL not set in production — search will be unavailable")
     else:
         ELASTICSEARCH_URL = "http://localhost:9200"
 

--- a/jobsy/shared/events.py
+++ b/jobsy/shared/events.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 EXCHANGE_NAME = "jobsy.events"
 DLX_NAME = "jobsy.events.dlx"
 MAX_RETRIES = 3
+CONNECTION_RETRIES = 5  # attempts before giving up on initial connection
 RECONNECT_DELAY = 10  # seconds between reconnection attempts
 
 # Module-level connection for reuse across publishes
@@ -27,13 +28,36 @@ _publish_connection: aio_pika.abc.AbstractRobustConnection | None = None
 
 
 async def get_connection():
-    """Get or create a reusable RabbitMQ connection for publishing."""
+    """Get or create a reusable RabbitMQ connection for publishing.
+
+    Retries with exponential backoff if the broker is temporarily
+    unreachable (e.g. DNS not yet propagated on Railway).
+    """
     global _publish_connection
     if not RABBITMQ_URL:
         return None
-    if _publish_connection is None or _publish_connection.is_closed:
-        _publish_connection = await aio_pika.connect_robust(RABBITMQ_URL)
-    return _publish_connection
+    if _publish_connection is not None and not _publish_connection.is_closed:
+        return _publish_connection
+
+    delay = 2
+    for attempt in range(1, CONNECTION_RETRIES + 1):
+        try:
+            _publish_connection = await aio_pika.connect_robust(RABBITMQ_URL)
+            return _publish_connection
+        except Exception:
+            if attempt == CONNECTION_RETRIES:
+                logger.warning(
+                    "RabbitMQ connection failed after %d attempts, giving up",
+                    CONNECTION_RETRIES,
+                )
+                return None
+            logger.warning(
+                "RabbitMQ connection attempt %d/%d failed, retrying in %ds",
+                attempt, CONNECTION_RETRIES, delay,
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 30)
+    return None
 
 
 async def close_connection():


### PR DESCRIPTION
## Summary
- **Removes hardcoded `*.railway.internal` DNS names** that were causing `AMQPConnectionError: Name or service not known` — Railway's internal DNS depends on the actual service name configured in the project
- **Adds flexible env var resolution for RabbitMQ**: checks `RABBITMQ_URL` → `CLOUDAMQP_URL` → builds from `RABBITMQ_HOST`/`RABBITMQ_PORT`/`RABBITMQ_USER`/`RABBITMQ_PASS`
- **Same pattern for Redis and Elasticsearch**: supports `REDIS_HOST`/`REDIS_PORT` and `ELASTICSEARCH_HOST`/`ELASTICSEARCH_PORT`
- **Adds retry with exponential backoff** to `get_connection()` in events.py (5 attempts, 2s→4s→8s→16s→30s) so the search service doesn't crash on transient DNS or connection failures
- Updates `railway.toml` to document the new env var options

## Root cause
PR #28 hardcoded `rabbitmq.railway.internal` as the fallback hostname, but Railway's private networking DNS uses `<service-name>.railway.internal` where the service name depends on how the project is configured. The DNS name wasn't resolving, causing immediate connection crashes.

## How to configure on Railway
Set **one** of these in your Railway service variables:
1. `RABBITMQ_URL=amqp://user:pass@your-rabbitmq-host:5672/` (full URL)
2. `CLOUDAMQP_URL=...` (auto-set by CloudAMQP plugin)
3. `RABBITMQ_HOST=rabbitmq.railway.internal` (or whatever your service is named) + optional `RABBITMQ_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASS`

## Test plan
- [ ] Set `RABBITMQ_HOST` to the actual Railway service name and deploy — verify connection succeeds
- [ ] Alternatively, install CloudAMQP plugin and verify `CLOUDAMQP_URL` is auto-detected
- [ ] Verify search service starts gracefully even if RabbitMQ is temporarily unavailable (retries instead of crashing)
- [ ] Verify local dev still uses localhost defaults

https://claude.ai/code/session_01FR7kGKM4HsQKzy1ttyWr5J