### PR TITLE
fix: return 200 on search health endpoint when elasticsearch is degraded

### DIFF
--- a/jobsy/search/app/main.py
+++ b/jobsy/search/app/main.py
@@ -4,7 +4,6 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
 
 from shared.logging import setup_json_logging
 from shared.middleware import setup_middleware
@@ -36,10 +35,10 @@ async def health():
     client = await get_client()
     if client:
         return {"status": "ok", "service": "search"}
-    return JSONResponse(
-        {"status": "degraded", "service": "search", "error": "elasticsearch unavailable"},
-        status_code=503,
-    )
+    # Return 200 with degraded status so Railway healthcheck passes.
+    # The service is running; Elasticsearch being unavailable is a
+    # dependency issue, not a service crash.
+    return {"status": "degraded", "service": "search", "detail": "elasticsearch unavailable"}
 
 
 app.include_router(router)


### PR DESCRIPTION
## Problem
The search service health endpoint was returning HTTP 503 when Elasticsearch was unavailable, causing Railway's healthcheck to fail and preventing deployment of any code changes.

## Root Cause
The `/health` endpoint in `search/app/main.py` returned a 503 status code when the Elasticsearch client was not available. Railway's healthcheck interprets any non-2xx response as a failure, which caused new deployments to be rolled back.

## Fix
Changed the health endpoint to return HTTP 200 with a `degraded` status when Elasticsearch is unavailable. The service itself is running correctly; Elasticsearch being unavailable is a dependency issue that should not prevent the service from starting or passing healthchecks.

This allows Railway deployments to succeed while still indicating the dependency status in the response body.