### PR TITLE
feat: add search button to homepage hero search input

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -125,6 +125,13 @@ p { margin-bottom: 1rem; }
 }
 .hero-search input::placeholder { color: rgba(255,255,255,0.6); }
 .hero-search input:focus { border-color: rgba(255,255,255,0.7); background: rgba(255,255,255,0.2); }
+.hero-search-btn {
+  position: absolute; right: 0.5rem; top: 50%; transform: translateY(-50%);
+  background: none; border: none; color: rgba(255,255,255,0.7);
+  cursor: pointer; padding: 0.5rem; display: flex; align-items: center;
+  transition: color 0.2s;
+}
+.hero-search-btn:hover { color: white; }
 .hero-stats {
   display: flex; justify-content: center; gap: 2rem; margin-top: 2rem;
   font-size: 0.875rem; color: rgba(255,255,255,0.85);

--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
       <div class="hero-search">
         <label for="hero-search" class="sr-only">Search services</label>
         <input type="text" id="hero-search" placeholder="Search services... (e.g. plumber, cleaner, tutor)" aria-label="Search services">
+        <button type="button" id="hero-search-btn" aria-label="Search" class="hero-search-btn">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
       </div>
       <div class="hero-stats">
         <div><span class="hero-stat-num" id="stat-listings">12+</span> Services</div>

--- a/js/common.js
+++ b/js/common.js
@@ -245,6 +245,21 @@ function initSearch() {
   const searchInput = document.getElementById('hero-search');
   if (!searchInput) return;
 
+  const searchBtn = document.getElementById('hero-search-btn');
+  if (searchBtn) {
+    searchBtn.addEventListener('click', () => {
+      clearTimeout(_searchTimeout);
+      searchInput.dispatchEvent(new Event('input'));
+    });
+  }
+
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      clearTimeout(_searchTimeout);
+      searchInput.dispatchEvent(new Event('input'));
+    }
+  });
+
   searchInput.addEventListener('input', () => {
     clearTimeout(_searchTimeout);
     const q = searchInput.value.trim();


### PR DESCRIPTION
Users had no visible way to submit a search query — the input only triggered on typing via debounce. Add a magnifying glass button inside the search field and wire up both button click and Enter key to trigger search immediately.

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU