### PR TITLE
feat: make platform production-ready

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="About Jobsy - Jamaica's Service Marketplace">
   <meta property="og:description" content="Learn about Jobsy, a Jamaican service marketplace for finding local professionals.">
   <meta property="og:type" content="website">

--- a/category.html
+++ b/category.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="Browse Services | Jobsy Jamaica">
   <meta property="og:description" content="Browse service providers by category and parish on Jobsy Jamaica.">
   <meta property="og:type" content="website">

--- a/contact.html
+++ b/contact.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="Contact Jobsy">
   <meta property="og:description" content="Register your business or get in touch with Jobsy Jamaica.">
   <meta property="og:type" content="website">

--- a/disclosure.html
+++ b/disclosure.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/disclosure.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/">
   <meta property="og:title" content="Jobsy - Find Service Providers in Jamaica">
   <meta property="og:description" content="Find local service providers across Jamaica. Browse by category or parish.">

--- a/jobsy/gateway/app/deps.py
+++ b/jobsy/gateway/app/deps.py
@@ -7,6 +7,9 @@ from jose import JWTError
 from shared.auth import decode_token
 
 security = HTTPBearer()
+optional_security = HTTPBearer(auto_error=False)
+
+_ANONYMOUS = {"user_id": "anonymous", "role": "anonymous"}
 
 
 async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> dict:
@@ -18,3 +21,18 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
         return {"user_id": payload["sub"], "role": payload.get("role", "user")}
     except JWTError as err:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token") from err
+
+
+async def get_optional_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(optional_security),
+) -> dict:
+    """Extract user from JWT if present, otherwise return anonymous context."""
+    if not credentials:
+        return _ANONYMOUS
+    try:
+        payload = decode_token(credentials.credentials)
+        if payload.get("type") != "access":
+            return _ANONYMOUS
+        return {"user_id": payload["sub"], "role": payload.get("role", "user")}
+    except JWTError:
+        return _ANONYMOUS

--- a/jobsy/gateway/app/routes/proxy.py
+++ b/jobsy/gateway/app/routes/proxy.py
@@ -6,7 +6,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from ..config import SERVICE_URLS
-from ..deps import get_current_user
+from ..deps import get_current_user, get_optional_user
 
 logger = logging.getLogger(__name__)
 
@@ -68,13 +68,27 @@ async def _proxy_request(service: str, path: str, request: Request, user: dict) 
     )
 
 
-@router.api_route("/profiles/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
-async def proxy_profiles(path: str, request: Request, user: dict = Depends(get_current_user)):
+@router.api_route("/profiles/{path:path}", methods=["GET"])
+async def proxy_profiles_read(path: str, request: Request, user: dict = Depends(get_optional_user)):
+    """Public read access to profiles."""
     return await _proxy_request("profiles", f"/{path}", request, user)
 
 
-@router.api_route("/listings/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
-async def proxy_listings(path: str, request: Request, user: dict = Depends(get_current_user)):
+@router.api_route("/profiles/{path:path}", methods=["POST", "PUT", "DELETE"])
+async def proxy_profiles_write(path: str, request: Request, user: dict = Depends(get_current_user)):
+    """Authenticated write access to profiles."""
+    return await _proxy_request("profiles", f"/{path}", request, user)
+
+
+@router.api_route("/listings/{path:path}", methods=["GET"])
+async def proxy_listings_read(path: str, request: Request, user: dict = Depends(get_optional_user)):
+    """Public read access to listings (browse, search, view)."""
+    return await _proxy_request("listings", f"/{path}", request, user)
+
+
+@router.api_route("/listings/{path:path}", methods=["POST", "PUT", "DELETE"])
+async def proxy_listings_write(path: str, request: Request, user: dict = Depends(get_current_user)):
+    """Authenticated write access to listings."""
     return await _proxy_request("listings", f"/{path}", request, user)
 
 
@@ -103,6 +117,13 @@ async def proxy_chat(path: str, request: Request, user: dict = Depends(get_curre
     return await _proxy_request("chat", f"/{path}", request, user)
 
 
+@router.post("/notifications/subscribe")
+async def proxy_newsletter_subscribe(request: Request):
+    """Public newsletter subscription (no auth required)."""
+    user = {"user_id": "anonymous", "role": "anonymous"}
+    return await _proxy_request("notifications", "/subscribe", request, user)
+
+
 @router.api_route("/notifications/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def proxy_notifications(path: str, request: Request, user: dict = Depends(get_current_user)):
     return await _proxy_request("notifications", f"/{path}", request, user)
@@ -123,13 +144,21 @@ async def proxy_payments(path: str, request: Request, user: dict = Depends(get_c
     return await _proxy_request("payments", f"/{path}", request, user)
 
 
-@router.api_route("/reviews/{path:path}", methods=["GET", "POST", "PUT"])
-async def proxy_reviews(path: str, request: Request, user: dict = Depends(get_current_user)):
+@router.api_route("/reviews/{path:path}", methods=["GET"])
+async def proxy_reviews_read(path: str, request: Request, user: dict = Depends(get_optional_user)):
+    """Public read access to reviews."""
+    return await _proxy_request("reviews", f"/{path}", request, user)
+
+
+@router.api_route("/reviews/{path:path}", methods=["POST", "PUT"])
+async def proxy_reviews_write(path: str, request: Request, user: dict = Depends(get_current_user)):
+    """Authenticated write access to reviews."""
     return await _proxy_request("reviews", f"/{path}", request, user)
 
 
 @router.api_route("/search/{path:path}", methods=["GET"])
-async def proxy_search(path: str, request: Request, user: dict = Depends(get_current_user)):
+async def proxy_search(path: str, request: Request, user: dict = Depends(get_optional_user)):
+    """Public search access (browse without login)."""
     return await _proxy_request("search", f"/{path}", request, user)
 
 

--- a/jobsy/notifications/app/models.py
+++ b/jobsy/notifications/app/models.py
@@ -21,6 +21,15 @@ class DeviceToken(Base):
     )
 
 
+class NewsletterSubscriber(Base):
+    __tablename__ = "newsletter_subscribers"
+
+    id = Column(String, primary_key=True)
+    email = Column(String(255), unique=True, nullable=False)
+    subscribed_at = Column(DateTime(timezone=True), nullable=False)
+    is_active = Column(Boolean, default=True)
+
+
 class NotificationLog(Base):
     __tablename__ = "notification_log"
 

--- a/jobsy/notifications/app/routes.py
+++ b/jobsy/notifications/app/routes.py
@@ -10,9 +10,34 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from shared.database import get_db
 
-from .models import DeviceToken, NotificationLog
+from .models import DeviceToken, NewsletterSubscriber, NotificationLog
 
 router = APIRouter(tags=["notifications"])
+
+
+class SubscribeRequest(BaseModel):
+    email: str = Field(..., max_length=255)
+
+
+@router.post("/subscribe", status_code=status.HTTP_201_CREATED)
+async def subscribe_newsletter(data: SubscribeRequest, db: AsyncSession = Depends(get_db)):
+    """Subscribe an email to the newsletter (no auth required)."""
+    result = await db.execute(
+        select(NewsletterSubscriber).where(NewsletterSubscriber.email == data.email)
+    )
+    existing = result.scalar_one_or_none()
+    if existing:
+        if not existing.is_active:
+            existing.is_active = True
+        return {"status": "subscribed", "email": data.email}
+
+    subscriber = NewsletterSubscriber(
+        id=str(uuid.uuid4()),
+        email=data.email,
+        subscribed_at=datetime.now(UTC),
+    )
+    db.add(subscriber)
+    return {"status": "subscribed", "email": data.email}
 
 
 def _get_user_id(request: Request) -> str:

--- a/jobsy/scripts/seed_data.py
+++ b/jobsy/scripts/seed_data.py
@@ -397,12 +397,13 @@ async def seed():
                 listing_id = _uid()
                 session.add(Listing(
                     id=listing_id,
-                    user_id=user_id,
+                    poster_id=user_id,
                     title=lst["title"],
                     description=lst["description"],
                     category=p["category"],
                     parish=p["parish"],
-                    budget=lst["budget"],
+                    budget_min=lst["budget"],
+                    budget_max=lst["budget"],
                     currency="JMD",
                     status="active",
                     created_at=_now(),

--- a/js/common.js
+++ b/js/common.js
@@ -39,29 +39,85 @@ const FALLBACK_LISTINGS = [
   { id: 'fb-12', title: 'Bathroom Renovation', description: 'Complete bathroom remodel including tiling, fixtures, and plumbing.', category: 'Construction', parish: 'St. Ann', budget: 120000, currency: 'JMD' }
 ];
 
+/* ===== Auth Helpers ===== */
+function getAuthToken() {
+  return localStorage.getItem('jobsy_access_token');
+}
+
+function setAuthTokens(access, refresh) {
+  localStorage.setItem('jobsy_access_token', access);
+  if (refresh) localStorage.setItem('jobsy_refresh_token', refresh);
+}
+
+function clearAuth() {
+  localStorage.removeItem('jobsy_access_token');
+  localStorage.removeItem('jobsy_refresh_token');
+}
+
+function isLoggedIn() {
+  const token = getAuthToken();
+  if (!token) return false;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.exp * 1000 > Date.now();
+  } catch { return false; }
+}
+
+function _authHeaders() {
+  const token = getAuthToken();
+  return token ? { 'Authorization': `Bearer ${token}` } : {};
+}
+
 /* ===== API Client ===== */
 const api = {
   async fetchListings(params = {}) {
     const qs = new URLSearchParams(params).toString();
-    const res = await fetch(`${API_URL}/api/listings${qs ? '?' + qs : ''}`, { signal: AbortSignal.timeout(5000) });
+    const res = await fetch(`${API_URL}/api/listings${qs ? '?' + qs : ''}`, {
+      headers: _authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    });
     if (!res.ok) throw new Error(`API ${res.status}`);
     return res.json();
   },
   async fetchListing(id) {
-    const res = await fetch(`${API_URL}/api/listings/${id}`, { signal: AbortSignal.timeout(5000) });
+    const res = await fetch(`${API_URL}/api/listings/${id}`, {
+      headers: _authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    });
     if (!res.ok) throw new Error(`API ${res.status}`);
     return res.json();
   },
   async searchListings(query, params = {}) {
     const qs = new URLSearchParams({ q: query, ...params }).toString();
-    const res = await fetch(`${API_URL}/api/search/listings?${qs}`, { signal: AbortSignal.timeout(5000) });
+    const res = await fetch(`${API_URL}/api/search/listings?${qs}`, {
+      headers: _authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    });
     if (!res.ok) throw new Error(`API ${res.status}`);
     return res.json();
   },
   async fetchProfile(userId) {
-    const res = await fetch(`${API_URL}/api/profiles/${userId}`, { signal: AbortSignal.timeout(5000) });
+    const res = await fetch(`${API_URL}/api/profiles/${userId}`, {
+      headers: _authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    });
     if (!res.ok) throw new Error(`API ${res.status}`);
     return res.json();
+  },
+  async login(phone, password) {
+    const res = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone, password }),
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || `Login failed: ${res.status}`);
+    }
+    const tokens = await res.json();
+    setAuthTokens(tokens.access_token, tokens.refresh_token);
+    return tokens;
   },
   async register(data) {
     const res = await fetch(`${API_URL}/auth/register`, {
@@ -74,7 +130,9 @@ const api = {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.detail || `Registration failed: ${res.status}`);
     }
-    return res.json();
+    const tokens = await res.json();
+    setAuthTokens(tokens.access_token, tokens.refresh_token);
+    return tokens;
   }
 };
 
@@ -134,6 +192,9 @@ function renderNav() {
         <a href="about.html">About</a>
         <a href="contact.html">Contact</a>
         <a href="https://t.me/JobsyDealBot" target="_blank" rel="noopener" class="btn btn-sm btn-accent">Telegram Bot</a>
+        ${isLoggedIn()
+          ? '<a href="#" class="btn btn-sm btn-outline" id="nav-logout">Log Out</a>'
+          : '<a href="login.html" class="btn btn-sm btn-outline">Log In</a>'}
       </div>
       <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false">&#9776;</button>
     </div>
@@ -151,6 +212,16 @@ function renderNav() {
   menu.querySelectorAll('a').forEach(link => {
     link.addEventListener('click', () => menu.classList.remove('open'));
   });
+
+  // Logout handler
+  const logoutBtn = nav.querySelector('#nav-logout');
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      clearAuth();
+      window.location.reload();
+    });
+  }
 }
 
 /* ===== Footer ===== */
@@ -217,8 +288,9 @@ function listingCardHTML(listing) {
   const icon = cat ? cat.icon : '💼';
   const catName = listing.category || 'Service';
   const parish = listing.parish || '';
-  const price = listing.budget
-    ? `J$${Number(listing.budget).toLocaleString()}`
+  const budgetVal = listing.budget_max || listing.budget_min || listing.budget;
+  const price = budgetVal
+    ? `J$${Number(budgetVal).toLocaleString()}`
     : 'Get Quote';
 
   return `

--- a/login.html
+++ b/login.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/login.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
@@ -20,29 +20,110 @@
         <h1>Log In</h1>
         <p class="text-muted">Access your Jobsy provider account</p>
 
-        <div class="content-section">
+        <div id="login-form-section" class="content-section">
+          <div id="form-message" style="display:none"></div>
+
+          <form id="login-form" novalidate>
+            <div class="form-group">
+              <label for="login-phone">Phone Number</label>
+              <input type="tel" id="login-phone" required placeholder="+1 876 123 4567">
+              <p class="hint">Jamaican mobile number used during registration</p>
+            </div>
+
+            <div class="form-group">
+              <label for="login-password">Password</label>
+              <input type="password" id="login-password" required placeholder="Your password">
+            </div>
+
+            <button type="submit" class="btn btn-primary btn-lg" id="login-submit" style="width:100%;justify-content:center">
+              Log In
+            </button>
+          </form>
+
+          <div style="margin-top:1.5rem;text-align:center">
+            <p class="text-muted">Don't have an account?</p>
+            <a href="contact.html#register" class="btn btn-outline" style="width:100%;justify-content:center;margin-top:0.5rem">Register as a Provider</a>
+          </div>
+        </div>
+
+        <!-- Shown after successful login -->
+        <div id="logged-in-section" class="content-section" style="display:none">
           <div class="sidebar-card" style="text-align:center;padding:2rem">
-            <div style="font-size:3rem;margin-bottom:1rem">🔐</div>
-            <h2 style="margin-bottom:0.75rem">Account Management Coming Soon</h2>
-            <p>We're building a provider dashboard where you'll be able to manage your listings, respond to inquiries, and track your business performance.</p>
-            <p>If you've already registered, we'll notify you by email when login is available.</p>
-          </div>
-
-          <div style="margin-top:1.5rem">
-            <h3>Not registered yet?</h3>
-            <p>Join Jobsy for free and start reaching customers across Jamaica.</p>
-            <a href="contact.html#register" class="btn btn-primary btn-lg" style="width:100%;justify-content:center;margin-bottom:1rem">Register as a Provider</a>
-          </div>
-
-          <div style="margin-top:1rem">
-            <h3>Need help with your account?</h3>
-            <p>If you need to update your listing or reset your password, contact us directly:</p>
-            <a href="mailto:jobsyja@jobsyja.com?subject=Account%20Help" class="btn btn-outline" style="width:100%;justify-content:center">Email Support</a>
+            <div style="font-size:3rem;margin-bottom:1rem">&#9989;</div>
+            <h2 style="margin-bottom:0.75rem">You're Logged In</h2>
+            <p>Welcome back to Jobsy!</p>
+            <a href="index.html" class="btn btn-primary btn-lg" style="width:100%;justify-content:center;margin-top:1rem">Browse Services</a>
+            <a href="#" class="btn btn-outline" id="logout-btn" style="width:100%;justify-content:center;margin-top:0.75rem">Log Out</a>
           </div>
         </div>
       </div>
     </div>
   </main>
+
   <script src="js/common.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const formSection = document.getElementById('login-form-section');
+      const loggedInSection = document.getElementById('logged-in-section');
+
+      // If already logged in, show logged-in state
+      if (isLoggedIn()) {
+        formSection.style.display = 'none';
+        loggedInSection.style.display = '';
+        document.getElementById('logout-btn').addEventListener('click', (e) => {
+          e.preventDefault();
+          clearAuth();
+          window.location.reload();
+        });
+        return;
+      }
+
+      const form = document.getElementById('login-form');
+      const msgEl = document.getElementById('form-message');
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        msgEl.style.display = 'none';
+
+        const phone = document.getElementById('login-phone').value.trim();
+        const password = document.getElementById('login-password').value;
+
+        if (!phone || !password) {
+          showMessage('Please enter your phone number and password.', 'error');
+          return;
+        }
+
+        const btn = document.getElementById('login-submit');
+        btn.disabled = true;
+        btn.textContent = 'Logging in...';
+
+        try {
+          await api.login(phone, password);
+          showMessage('Login successful! Redirecting...', 'success');
+          setTimeout(() => { window.location.href = 'index.html'; }, 1000);
+        } catch (err) {
+          const isNetworkError = err.message === 'Failed to fetch' || err.name === 'TypeError' || err.name === 'AbortError';
+          if (isNetworkError) {
+            showMessage(
+              'Cannot reach the server. For account help, email <a href="mailto:jobsyja@jobsyja.com" style="color:var(--primary);text-decoration:underline">jobsyja@jobsyja.com</a>.',
+              'error'
+            );
+          } else {
+            showMessage(err.message || 'Invalid phone number or password.', 'error');
+          }
+        } finally {
+          btn.disabled = false;
+          btn.textContent = 'Log In';
+        }
+      });
+
+      function showMessage(html, type) {
+        msgEl.innerHTML = html;
+        msgEl.className = 'form-message ' + type;
+        msgEl.style.display = 'block';
+        msgEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    });
+  </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/privacy.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">

--- a/provider.html
+++ b/provider.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="Service Provider | Jobsy Jamaica">
   <meta property="og:description" content="View service provider details and listings on Jobsy Jamaica.">
   <meta property="og:type" content="website">
@@ -51,8 +51,9 @@
       // Try fetching from API, then fall back to local data
       try {
         listing = await api.fetchListing(listingId);
-        if (listing.user_id) {
-          try { profile = await api.fetchProfile(listing.user_id); } catch {}
+        const providerId = listing.poster_id || listing.user_id;
+        if (providerId) {
+          try { profile = await api.fetchProfile(providerId); } catch {}
         }
       } catch {
         // Check fallback listings
@@ -72,8 +73,9 @@
 
       const cat = findCategory(listing.category);
       const icon = cat ? cat.icon : '💼';
-      const price = listing.budget
-        ? `J$${Number(listing.budget).toLocaleString()} ${listing.currency || 'JMD'}`
+      const budgetVal = listing.budget_max || listing.budget_min || listing.budget;
+      const price = budgetVal
+        ? `J$${Number(budgetVal).toLocaleString()} ${listing.currency || 'JMD'}`
         : 'Get Quote';
 
       container.innerHTML = `

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/terms.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
- Add get_optional_user dep for public browsing without JWT auth
- Split proxy routes: listings/search/profiles/reviews GET is public, write operations still require auth
- Add newsletter /subscribe endpoint + NewsletterSubscriber model
- Fix seed_data.py: use poster_id and budget_min/budget_max to match the Listing ORM model
- Fix frontend field mapping: handle both budget and budget_min/budget_max, poster_id and user_id
- Add auth helpers (login/logout/token management) to common.js
- Replace login.html placeholder with working phone+password login form
- Add Log In / Log Out button to nav bar
- Update CSP connect-src in all HTML files to allow localhost:8000

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU