### PR TITLE
fix: add missing redis dependency to admin service requirements

### DIFF
--- a/jobsy/admin/requirements.txt
+++ b/jobsy/admin/requirements.txt
@@ -5,4 +5,5 @@ asyncpg>=0.29.0
 pydantic>=2.5.0
 pydantic-settings>=2.1.0
 httpx>=0.25.0
+redis>=5.0.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
The admin service crashes on Railway with ModuleNotFoundError because redis>=5.0.0 was not listed in admin/requirements.txt after adding Redis caching for dashboard stats.

https://claude.ai/code/session_01PxWERMemUZLRLfa81XN9tU