### PR TITLE
fix: add HTTP CORS origins for jobsyja.com

### DIFF
--- a/jobsy/gateway/app/main.py
+++ b/jobsy/gateway/app/main.py
@@ -52,6 +52,8 @@ ALLOWED_ORIGINS = [
     "exp://localhost:19000",
     "https://www.jobsyja.com",
     "https://jobsyja.com",
+    "http://www.jobsyja.com",
+    "http://jobsyja.com",
     "jobsy://",
     "com.jobsy.app://",
 ]


### PR DESCRIPTION
The site may be served over plain HTTP, but only https:// origins were in the CORS allowlist. This caused the browser to block preflight requests from http://jobsyja.com, resulting in "Failed to fetch" errors on the registration and login forms.

https://claude.ai/code/session_01XMFxXRUSfrGe9YrnhgfdMt