### PR TITLE
fix: ensure all frontends correctly connect to the gateway on Railway

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="About Jobsy - Jamaica's Service Marketplace">
   <meta property="og:description" content="Learn about Jobsy, a Jamaican service marketplace for finding local professionals.">
   <meta property="og:type" content="website">

--- a/category.html
+++ b/category.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="Browse Services | Jobsy Jamaica">
   <meta property="og:description" content="Browse service providers by category and parish on Jobsy Jamaica.">
   <meta property="og:type" content="website">

--- a/contact.html
+++ b/contact.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="Contact Jobsy">
   <meta property="og:description" content="Register your business or get in touch with Jobsy Jamaica.">
   <meta property="og:type" content="website">

--- a/create-listing.html
+++ b/create-listing.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
   <style>

--- a/disclosure.html
+++ b/disclosure.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/disclosure.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">

--- a/edit-profile.html
+++ b/edit-profile.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/">
   <meta property="og:title" content="Jobsy - Find Service Providers in Jamaica">
   <meta property="og:description" content="Find local service providers across Jamaica. Browse by category or parish.">

--- a/jobsy/mobile/.env.example
+++ b/jobsy/mobile/.env.example
@@ -1,4 +1,13 @@
+# Local development
 EXPO_PUBLIC_API_URL=http://localhost:8000
 EXPO_PUBLIC_WS_URL=ws://localhost:8000
+
+# Production (uncomment and set your Railway or custom domain)
+# EXPO_PUBLIC_API_URL=https://api.jobsyja.com
+# EXPO_PUBLIC_WS_URL=wss://api.jobsyja.com
+# Or if using Railway's auto-generated domain:
+# EXPO_PUBLIC_API_URL=https://gateway-production-xxxx.up.railway.app
+# EXPO_PUBLIC_WS_URL=wss://gateway-production-xxxx.up.railway.app
+
 EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=868545444077-unsoo0vl887552vfvl2029dg2bh8mfs8.apps.googleusercontent.com

--- a/jobsy/shared/middleware.py
+++ b/jobsy/shared/middleware.py
@@ -20,7 +20,7 @@ def setup_middleware(app: FastAPI, allowed_origins: list[str] | None = None) -> 
         CORSMiddleware,
         allow_origins=origins,
         allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
     )
 

--- a/js/common.js
+++ b/js/common.js
@@ -2,9 +2,10 @@
 
 const SITE_NAME = 'Jobsy';
 const BASE_URL = 'https://www.jobsyja.com';
+const RAILWAY_API_URL = ''; // Set to Railway domain if custom domain not ready, e.g. 'https://gateway-production-xxxx.up.railway.app'
 const API_URL = ['localhost', '127.0.0.1'].includes(location.hostname)
   ? 'http://localhost:8000'
-  : 'https://api.jobsyja.com';
+  : (RAILWAY_API_URL || 'https://api.jobsyja.com');
 const ADSENSE_PUB_ID = ''; // Paste your AdSense publisher ID here
 
 /* ===== Service Categories ===== */

--- a/login.html
+++ b/login.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/login.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
@@ -237,7 +237,11 @@
           showMessage('Account created! Redirecting...', 'success');
           setTimeout(() => { window.location.href = 'dashboard.html'; }, 1000);
         } catch (err) {
-          showMessage(err.message || 'Registration failed. Please try again.', 'error');
+          if (err.message === 'Failed to fetch' || err.name === 'TypeError' || err.name === 'AbortError') {
+            showMessageHTML('Cannot reach the server. Please try again later or email <a href="mailto:jobsyja@jobsyja.com" style="color:var(--primary);text-decoration:underline">jobsyja@jobsyja.com</a> for help.', 'error');
+          } else {
+            showMessage(err.message || 'Registration failed. Please try again.', 'error');
+          }
         } finally { btn.disabled = false; btn.textContent = 'Create Account'; }
       });
 
@@ -258,7 +262,11 @@
           document.getElementById('forgot-step2').style.display = '';
           showMessage('If this phone is registered, you will receive a reset code via SMS.', 'success');
         } catch (err) {
-          showMessage(err.message || 'Failed to send reset code.', 'error');
+          if (err.message === 'Failed to fetch' || err.name === 'TypeError' || err.name === 'AbortError') {
+            showMessageHTML('Cannot reach the server. Please try again later or email <a href="mailto:jobsyja@jobsyja.com" style="color:var(--primary);text-decoration:underline">jobsyja@jobsyja.com</a> for help.', 'error');
+          } else {
+            showMessage(err.message || 'Failed to send reset code.', 'error');
+          }
         } finally { btn.disabled = false; btn.textContent = 'Send Reset Code'; }
       });
 
@@ -278,7 +286,11 @@
           showMessage('Password reset! Redirecting to dashboard...', 'success');
           setTimeout(() => { window.location.href = 'dashboard.html'; }, 1000);
         } catch (err) {
-          showMessage(err.message || 'Invalid or expired reset code.', 'error');
+          if (err.message === 'Failed to fetch' || err.name === 'TypeError' || err.name === 'AbortError') {
+            showMessageHTML('Cannot reach the server. Please try again later or email <a href="mailto:jobsyja@jobsyja.com" style="color:var(--primary);text-decoration:underline">jobsyja@jobsyja.com</a> for help.', 'error');
+          } else {
+            showMessage(err.message || 'Invalid or expired reset code.', 'error');
+          }
         } finally { btn.disabled = false; btn.textContent = 'Reset Password'; }
       });
 

--- a/messages.html
+++ b/messages.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000 wss://api.jobsyja.com ws://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000 wss://api.jobsyja.com wss://*.up.railway.app ws://localhost:8000; frame-src 'none'">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">
   <style>

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/privacy.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">

--- a/provider.html
+++ b/provider.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <meta property="og:title" content="Service Provider | Jobsy Jamaica">
   <meta property="og:description" content="View service provider details and listings on Jobsy Jamaica.">
   <meta property="og:type" content="website">

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com http://localhost:8000; frame-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.jobsyja.com https://*.up.railway.app http://localhost:8000; frame-src 'none'">
   <link rel="canonical" href="https://www.jobsyja.com/terms.html">
   <link rel="icon" type="image/svg+xml" href="images/logo.svg">
   <link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
- Add PATCH to CORS allowed methods (gateway supports PATCH for listings but CORS preflight was rejecting it)
- Add https://*.up.railway.app to CSP connect-src on all 14 HTML pages so the browser allows connections to Railway's auto-generated domain when the custom domain isn't configured yet
- Add RAILWAY_API_URL fallback constant in common.js for easy switching between custom domain and Railway's generated domain
- Fix "Failed to fetch" error handling in login.html signup, forgot- password, and reset-password forms to show actionable contact info (matching the existing login form pattern)
- Document production API URLs in mobile .env.example

https://claude.ai/code/session_01XMFxXRUSfrGe9YrnhgfdMt