### PR TITLE
feat: add Slack alerting integration

### DIFF
--- a/jobsy/.env.example
+++ b/jobsy/.env.example
@@ -103,6 +103,11 @@ PAYPAL_MODE=sandbox
 POSTHOG_API_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
 
+# --- Slack (Alerting) ---
+SLACK_BOT_TOKEN=
+SLACK_SIGNING_SECRET=
+SLACK_DEFAULT_CHANNEL=#alerts
+
 # --- Revive Adserver (optional -- falls back to local campaigns) ---
 # REVIVE_BASE_URL=http://localhost:8080
 # REVIVE_API_KEY=

--- a/jobsy/gateway/app/integrations/slack_client.py
+++ b/jobsy/gateway/app/integrations/slack_client.py
@@ -1,0 +1,44 @@
+"""Slack alerting integration via chat.postMessage API."""
+
+import logging
+
+import httpx
+
+from shared.config import SLACK_BOT_TOKEN, SLACK_DEFAULT_CHANNEL
+
+logger = logging.getLogger(__name__)
+
+
+async def send_alert(message: str, channel: str | None = None) -> bool:
+    """Send an alert message to a Slack channel.
+
+    Returns True if the message was posted successfully.
+    """
+    if not SLACK_BOT_TOKEN:
+        logger.warning("SLACK_BOT_TOKEN not set, Slack alerting disabled")
+        return False
+
+    target_channel = channel or SLACK_DEFAULT_CHANNEL
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://slack.com/api/chat.postMessage",
+                headers={"Authorization": f"Bearer {SLACK_BOT_TOKEN}"},
+                json={
+                    "channel": target_channel,
+                    "text": message,
+                },
+                timeout=10,
+            )
+            data = resp.json()
+            if resp.status_code == 200 and data.get("ok"):
+                return True
+            logger.error(
+                "Slack API error: status=%s ok=%s error=%s",
+                resp.status_code,
+                data.get("ok"),
+                data.get("error"),
+            )
+    except Exception:
+        logger.exception("Slack alert failed")
+    return False

--- a/jobsy/gateway/requirements.txt
+++ b/jobsy/gateway/requirements.txt
@@ -23,3 +23,4 @@ resend>=0.7.0
 sendgrid>=6.11.0
 paypalrestsdk>=1.13.0
 posthog>=3.3.0
+slack_sdk>=3.27.0

--- a/jobsy/requirements-test.txt
+++ b/jobsy/requirements-test.txt
@@ -41,3 +41,4 @@ resend>=0.7.0
 sendgrid>=6.11.0
 paypalrestsdk>=1.13.0
 posthog>=3.0.0
+slack_sdk>=3.27.0

--- a/jobsy/shared/config.py
+++ b/jobsy/shared/config.py
@@ -132,3 +132,8 @@ PAYPAL_MODE = os.getenv("PAYPAL_MODE", "sandbox")
 # PostHog (Product Analytics)
 POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY", "")
 POSTHOG_HOST = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
+
+# Slack (Alerting)
+SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN", "")
+SLACK_SIGNING_SECRET = os.getenv("SLACK_SIGNING_SECRET", "")
+SLACK_DEFAULT_CHANNEL = os.getenv("SLACK_DEFAULT_CHANNEL", "#alerts")


### PR DESCRIPTION
## Summary
- Add Slack alerting client at `gateway/app/integrations/slack_client.py` using httpx to call Slack's `chat.postMessage` API, following the same pattern as `email_service.py` and `analytics.py`
- Add `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, and `SLACK_DEFAULT_CHANNEL` env vars to `shared/config.py` and `.env.example`
- Add `slack_sdk>=3.27.0` to gateway and test requirements

## Test plan
- [x] Ruff linting passes
- [x] All 94 existing tests pass
- [ ] Verify Slack alert delivery with a valid bot token in staging

---
🤖 *Generated by Computer*